### PR TITLE
Add neo4j-driver-skill for modern driver best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Assists with upgrading Cypher queries to newer Neo4j versions.
 - Migrating databases from Neo4j 4.x or 5.x to 2025.x or 2026.x
 - Updating Cypher queries to a newer major Neo4j version
 
+### neo4j-driver-skill
+
+Modern best practices for the official Neo4j drivers (Python, JavaScript, Java, Go, .NET), centered on the `execute_query` API.
+
+**Use this skill when:**
+- Writing or reviewing code that uses an official Neo4j driver
+- Converting old session/transaction code to the `execute_query` API
+- Reaching for `record.data()` / `record.toObject()` / `AsMap()` and related result helpers
+
 ## Installation
 
 ### Using npx skills (Recommended)
@@ -70,6 +79,7 @@ git clone https://github.com/neo4j-contrib/neo4j-skills.git
 ln -s $(pwd)/neo4j-skills/neo4j-cypher-skill ~/.claude/skills/
 ln -s $(pwd)/neo4j-skills/neo4j-migration-skill ~/.claude/skills/
 ln -s $(pwd)/neo4j-skills/neo4j-cli-tools-skill ~/.claude/skills/
+ln -s $(pwd)/neo4j-skills/neo4j-driver-skill ~/.claude/skills/
 ```
 
 #### For other agents:

--- a/neo4j-driver-skill/SKILL.md
+++ b/neo4j-driver-skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: neo4j-driver-skill
+description: Use when writing or reviewing code that uses an official Neo4j driver (Python, JavaScript, Java, Go, .NET). Covers the modern execute_query API, parameters, routing, result access, and common pitfalls.
+allowed-tools: WebFetch
+---
+
+# Neo4j Driver skill
+
+Modern guidance for the five official Neo4j drivers. The APIs have converged on a single high-level entry point (`execute_query` / `executableQuery` / `ExecuteQuery`) that replaces most hand-written session+transaction code.
+
+## When to use
+
+Use this skill when code:
+- imports `neo4j` (Python), `neo4j-driver` (JavaScript), `org.neo4j.driver` (Java), `github.com/neo4j/neo4j-go-driver` (Go), or `Neo4j.Driver` (.NET)
+- uses `driver.session(...)`, `session.run(...)`, `session.execute_read/write`, or older transaction patterns
+- is being written from scratch against Neo4j
+- is being reviewed for driver correctness or performance
+
+## Core rules (apply to all languages)
+
+1. **`execute_query` is the default.** One call, one transaction, auto-retry on transient errors. Only drop to `session.execute_read/execute_write` when you need to interleave client-side logic between queries in one transaction.
+2. **Always pass the database name** (`database_="neo4j"`, `{database:'neo4j'}`, `WithDatabase`, etc.). Otherwise the driver makes an extra round-trip per query to resolve the default.
+3. **Always parameterize** with `$name` placeholders. Never string-concatenate values. Parameters enable query-plan caching and prevent Cypher injection.
+4. **One driver per application**, shared across threads/requests. The driver owns a connection pool — do not create it per request. Close on shutdown (or use `with` / `try-with-resources` / `using`).
+5. **Specify routing on read-heavy calls** in a cluster (`routing_="r"`, `routing: 'READ'`, `WithRouting(READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
+6. **Bulk writes use `UNWIND $rows AS row`** with a list parameter — one round-trip for thousands of rows. Do not loop over `execute_query`.
+7. **`execute_query` is eager** — it loads all records into memory. For huge result sets, use a session with `execute_read`/`execute_write` and iterate the `Result` without materializing it.
+8. **Prefer `CREATE` over `MERGE`** when you know the data is new. `MERGE` does a match + create; `CREATE` is one step.
+9. **Dynamic labels, relationship types, and property keys** — supported natively in Cypher 25 via the `$(expr)` syntax: `MATCH (n:$($label) {$($key): $value})` or `MERGE ()-[:$($type)]->()`. On Cypher 5 a plain parameter can only be a value; for dynamic labels/keys there, validate against an allow-list and interpolate, or call `apoc.merge.node` / `apoc.create.relationship`.
+
+## Getting records as dicts/JSON
+
+Each driver has a one-call conversion from a record to a plain map/dict — use it rather than reading fields one by one:
+
+| Language   | Call                    | Returns                  |
+|------------|-------------------------|--------------------------|
+| Python     | `record.data()`         | `dict`                   |
+| JavaScript | `record.toObject()`     | plain object             |
+| Java       | `record.asMap()`        | `Map<String,Object>`     |
+| Go         | `record.AsMap()`        | `map[string]any`         |
+| .NET       | `record.AsObject()` or `record.Values` | `IDictionary<string,object>` |
+
+Neo4j `Node`/`Relationship`/`Path` values inside a record are driver-specific objects. If you need plain JSON, either `RETURN` their properties explicitly (`RETURN n.name, n.age`) or apply a recursive-conversion transformer.
+
+## Per-language references
+
+Load the reference file for the language in the codebase:
+
+- Python → [python.md](references/python.md)
+- JavaScript / TypeScript → [javascript.md](references/javascript.md)
+- Java → [java.md](references/java.md)
+- Go → [go.md](references/go.md)
+- .NET / C# → [dotnet.md](references/dotnet.md)
+
+## Instructions
+
+1. Detect the driver language from the dependency file (`requirements.txt`, `package.json`, `pom.xml`/`build.gradle`, `go.mod`, `*.csproj`).
+2. Load the matching reference file above.
+3. When writing new code, start from the "Canonical example" in the reference — do not hand-roll sessions unless rule 1 requires it.
+4. When reviewing code, flag any of the nine core rules being broken.
+
+## Resources
+
+- [Python Driver Manual](https://neo4j.com/docs/python-manual/current/)
+- [JavaScript Driver Manual](https://neo4j.com/docs/javascript-manual/current/)
+- [Java Driver Manual](https://neo4j.com/docs/java-manual/current/)
+- [Go Driver Manual](https://neo4j.com/docs/go-manual/current/)
+- [.NET Driver Manual](https://neo4j.com/docs/dotnet-manual/current/)
+- [Supported versions matrix](https://neo4j.com/developer/kb/neo4j-supported-versions/)

--- a/neo4j-driver-skill/SKILL.md
+++ b/neo4j-driver-skill/SKILL.md
@@ -20,13 +20,14 @@ Use this skill when code:
 
 1. **`execute_query` is the default.** One call, one transaction, auto-retry on transient errors. Only drop to `session.execute_read/execute_write` when you need to interleave client-side logic between queries in one transaction.
 2. **Self-managing transaction queries need `session.run` (auto-commit).** `CALL {...} IN TRANSACTIONS` and `USING PERIODIC COMMIT` manage their own transactions and fail inside a managed transaction — so neither `execute_query` nor `session.execute_read/write` work. Open a session and run them with `session.run(...)`.
-3. **Always parameterize** with `$name` placeholders. Never string-concatenate values. Parameters enable query-plan caching and prevent Cypher injection.
-4. **One driver per application**, shared across threads/requests. The driver owns a connection pool — do not create it per request. Close on shutdown (or use `with` / `try-with-resources` / `using`).
-5. **Specify routing on read-only calls** in a cluster (`routing_=RoutingControl.READ`, `routing: neo4j.routing.READ`, `.withRouting(RoutingControl.READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
-6. **Bulk writes use `UNWIND $rows AS row`** with a list parameter — one round-trip for thousands of rows. Do not loop over `execute_query`.
-7. **`execute_query` is eager** — it loads all records into memory. For huge result sets, use a session with `execute_read`/`execute_write` and iterate the `Result` without materializing it.
-8. **Prefer `CREATE` over `MERGE`** when you know the data is new. `MERGE` does a match + create; `CREATE` is one step.
-9. **Dynamic labels, relationship types, and property keys** — supported natively in Cypher 25 via the `$(expr)` syntax: `MATCH (n:$($label) {$($key): $value})` or `MERGE ()-[:$($type)]->()`. On Cypher 5 a plain parameter can only be a value; for dynamic labels/keys there, validate against an allow-list and interpolate, or call `apoc.merge.node` / `apoc.create.relationship`.
+3. **Configure the database name explicitly** (`database_="neo4j"`, `{database:'neo4j'}`, `.withDatabase(...)`, `ExecuteQueryWithDatabase(...)`) unless you specifically want home-database resolution. Otherwise the driver pays an extra round-trip per query to resolve the default.
+4. **Always parameterize** with `$name` placeholders. Never string-concatenate values. Parameters enable query-plan caching and prevent Cypher injection.
+5. **One driver per application**, shared across threads/requests. The driver owns a connection pool — do not create it per request. Close on shutdown (or use `with` / `try-with-resources` / `using`).
+6. **Specify routing on read-only calls** in a cluster (`routing_=RoutingControl.READ`, `routing: neo4j.routing.READ`, `.withRouting(RoutingControl.READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
+7. **Bulk writes use `UNWIND $rows AS row`** with a list parameter — one round-trip for thousands of rows. Do not loop over `execute_query`.
+8. **`execute_query` is eager** — it loads all records into memory. For huge result sets, use a session with `execute_read`/`execute_write` and iterate the `Result` without materializing it.
+9. **Prefer `CREATE` over `MERGE`** when you know the data is new. `MERGE` does a match + create; `CREATE` is one step.
+10. **Dynamic labels, relationship types, and property keys** — supported natively in Cypher 25 via the `$(expr)` syntax: `MATCH (n:$($label) {$($key): $value})` or `MERGE ()-[:$($type)]->()`. On Cypher 5 a plain parameter can only be a value; for dynamic labels/keys there, validate against an allow-list and interpolate, or call `apoc.merge.node` / `apoc.create.relationship`.
 
 ## Reading record fields
 
@@ -51,7 +52,7 @@ Load the reference file for the language in the codebase:
 1. Detect the driver language from the dependency file (`requirements.txt`, `package.json`, `pom.xml`/`build.gradle`, `go.mod`, `*.csproj`).
 2. Load the matching reference file above.
 3. When writing new code, start from the "Canonical example" in the reference — do not hand-roll sessions unless rule 1 requires it.
-4. When reviewing code, flag any of the nine core rules being broken.
+4. When reviewing code, flag any of the ten core rules being broken.
 
 ## Resources
 

--- a/neo4j-driver-skill/SKILL.md
+++ b/neo4j-driver-skill/SKILL.md
@@ -19,28 +19,22 @@ Use this skill when code:
 ## Core rules (apply to all languages)
 
 1. **`execute_query` is the default.** One call, one transaction, auto-retry on transient errors. Only drop to `session.execute_read/execute_write` when you need to interleave client-side logic between queries in one transaction.
-2. **Always pass the database name** (`database_="neo4j"`, `{database:'neo4j'}`, `WithDatabase`, etc.). Otherwise the driver makes an extra round-trip per query to resolve the default.
+2. **Self-managing transaction queries need `session.run` (auto-commit).** `CALL {...} IN TRANSACTIONS` and `USING PERIODIC COMMIT` manage their own transactions and fail inside a managed transaction — so neither `execute_query` nor `session.execute_read/write` work. Open a session and run them with `session.run(...)`.
 3. **Always parameterize** with `$name` placeholders. Never string-concatenate values. Parameters enable query-plan caching and prevent Cypher injection.
 4. **One driver per application**, shared across threads/requests. The driver owns a connection pool — do not create it per request. Close on shutdown (or use `with` / `try-with-resources` / `using`).
-5. **Specify routing on read-only calls** in a cluster (`routing_="r"`, `routing: 'READ'`, `WithRouting(READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
+5. **Specify routing on read-only calls** in a cluster (`routing_=RoutingControl.READ`, `routing: neo4j.routing.READ`, `.withRouting(RoutingControl.READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
 6. **Bulk writes use `UNWIND $rows AS row`** with a list parameter — one round-trip for thousands of rows. Do not loop over `execute_query`.
 7. **`execute_query` is eager** — it loads all records into memory. For huge result sets, use a session with `execute_read`/`execute_write` and iterate the `Result` without materializing it.
 8. **Prefer `CREATE` over `MERGE`** when you know the data is new. `MERGE` does a match + create; `CREATE` is one step.
 9. **Dynamic labels, relationship types, and property keys** — supported natively in Cypher 25 via the `$(expr)` syntax: `MATCH (n:$($label) {$($key): $value})` or `MERGE ()-[:$($type)]->()`. On Cypher 5 a plain parameter can only be a value; for dynamic labels/keys there, validate against an allow-list and interpolate, or call `apoc.merge.node` / `apoc.create.relationship`.
 
-## Getting records as dicts/JSON
+## Reading record fields
 
-Each driver has a one-call conversion from a record to a plain map/dict — use it rather than reading fields one by one:
+Read fields by name — `record["name"]`, `record.get("name")`, `record["name"].As<T>()`, etc. — and only pull what you need.
 
-| Language   | Call                    | Returns                  |
-|------------|-------------------------|--------------------------|
-| Python     | `record.data()`         | `dict`                   |
-| JavaScript | `record.toObject()`     | plain object             |
-| Java       | `record.asMap()`        | `Map<String,Object>`     |
-| Go         | `record.AsMap()`        | `map[string]any`         |
-| .NET       | `record.AsObject()` or `record.Values` | `IDictionary<string,object>` |
+Each driver also exposes a whole-record map conversion (`record.data()` in Python, `record.toObject()` in JS, `record.asMap()` in Java, `record.AsMap()` in Go, `record.Values` / `record.AsObject()` in .NET). These are convenient for interactive sessions, logging, and quick prototyping, but they materialize every field even when you only need some.
 
-Neo4j `Node`/`Relationship`/`Path` values inside a record are driver-specific objects. If you need plain JSON, either `RETURN` their properties explicitly (`RETURN n.name, n.age`) or apply a recursive-conversion transformer.
+If you actually need JSON, either `RETURN` the exact primitive fields you want (`RETURN n.name, n.age`) or apply a purpose-built transformer.
 
 ## Per-language references
 

--- a/neo4j-driver-skill/SKILL.md
+++ b/neo4j-driver-skill/SKILL.md
@@ -22,7 +22,7 @@ Use this skill when code:
 2. **Always pass the database name** (`database_="neo4j"`, `{database:'neo4j'}`, `WithDatabase`, etc.). Otherwise the driver makes an extra round-trip per query to resolve the default.
 3. **Always parameterize** with `$name` placeholders. Never string-concatenate values. Parameters enable query-plan caching and prevent Cypher injection.
 4. **One driver per application**, shared across threads/requests. The driver owns a connection pool — do not create it per request. Close on shutdown (or use `with` / `try-with-resources` / `using`).
-5. **Specify routing on read-heavy calls** in a cluster (`routing_="r"`, `routing: 'READ'`, `WithRouting(READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
+5. **Specify routing on read-only calls** in a cluster (`routing_="r"`, `routing: 'READ'`, `WithRouting(READ)`, `ExecuteQueryWithReadersRouting()`). It sends reads to follower nodes.
 6. **Bulk writes use `UNWIND $rows AS row`** with a list parameter — one round-trip for thousands of rows. Do not loop over `execute_query`.
 7. **`execute_query` is eager** — it loads all records into memory. For huge result sets, use a session with `execute_read`/`execute_write` and iterate the `Result` without materializing it.
 8. **Prefer `CREATE` over `MERGE`** when you know the data is new. `MERGE` does a match + create; `CREATE` is one step.

--- a/neo4j-driver-skill/references/dotnet.md
+++ b/neo4j-driver-skill/references/dotnet.md
@@ -16,7 +16,9 @@ await driver.VerifyConnectivityAsync();
 var result = await driver
     .ExecutableQuery("MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
     .WithParameters(new { name = "Alice" })
-    .WithConfig(new QueryConfig(routing: RoutingControl.Readers))
+    .WithConfig(new QueryConfig(
+        database: "neo4j",
+        routing: RoutingControl.Readers))
     .ExecuteAsync();
 
 foreach (var record in result.Result)
@@ -40,6 +42,7 @@ foreach (var record in result.Result)
 ```csharp
 var names = await driver
     .ExecutableQuery("MATCH (p:Person) RETURN p.name AS name")
+    .WithConfig(new QueryConfig(database: "neo4j"))
     .WithMap(r => r["name"].As<string>())
     .ExecuteAsync();
 // names.Result is IReadOnlyList<string>
@@ -56,13 +59,14 @@ var rows = new[] {
 await driver
     .ExecutableQuery("UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
     .WithParameters(new { rows })
+    .WithConfig(new QueryConfig(database: "neo4j"))
     .ExecuteAsync();
 ```
 
 ## When to drop to a session
 
 ```csharp
-await using var session = driver.AsyncSession();
+await using var session = driver.AsyncSession(o => o.WithDatabase("neo4j"));
 
 await session.ExecuteWriteAsync(async tx =>
 {

--- a/neo4j-driver-skill/references/dotnet.md
+++ b/neo4j-driver-skill/references/dotnet.md
@@ -1,0 +1,87 @@
+# .NET driver (`Neo4j.Driver`)
+
+Install: `dotnet add package Neo4j.Driver`.
+
+## Canonical example
+
+```csharp
+using Neo4j.Driver;
+
+await using var driver = GraphDatabase.Driver(
+    "neo4j://localhost:7687",
+    AuthTokens.Basic("neo4j", "password"));
+
+await driver.VerifyConnectivityAsync();
+
+var result = await driver
+    .ExecutableQuery("MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
+    .WithParameters(new { name = "Alice" })
+    .WithConfig(new QueryConfig(
+        database: "neo4j",
+        routing: RoutingControl.Readers))
+    .ExecuteAsync();
+
+foreach (var record in result.Result)
+{
+    var map = record.Values;           // IReadOnlyDictionary<string, object>
+    var name = record["name"].As<string>();
+}
+```
+
+`ExecuteAsync()` returns an `EagerResult<IReadOnlyList<IRecord>>` exposing `Result`, `Summary`, `Keys`.
+
+## Accessing fields
+
+- `record["name"].As<string>()` — typed extraction
+- `record.Get<int>("age")` — typed extraction by name
+- `record.Values` — whole record as `IReadOnlyDictionary<string, object>`
+- `record.Keys` — column names
+
+## Mapped results
+
+```csharp
+var names = await driver
+    .ExecutableQuery("MATCH (p:Person) RETURN p.name AS name")
+    .WithConfig(new QueryConfig(database: "neo4j"))
+    .WithMap(r => r["name"].As<string>())
+    .ExecuteAsync();
+// names.Result is IReadOnlyList<string>
+```
+
+## Bulk writes
+
+```csharp
+var rows = new[] {
+    new { id = 1, name = "Alice" },
+    new { id = 2, name = "Bob" }
+};
+
+await driver
+    .ExecutableQuery("UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
+    .WithParameters(new { rows })
+    .WithConfig(new QueryConfig(database: "neo4j"))
+    .ExecuteAsync();
+```
+
+## When to drop to a session
+
+```csharp
+await using var session = driver.AsyncSession(o => o.WithDatabase("neo4j"));
+
+await session.ExecuteWriteAsync(async tx =>
+{
+    var r = await tx.RunAsync(
+        "MATCH (a:Account {id:$id}) RETURN a.balance AS b",
+        new { id = fromId });
+    var rec = await r.SingleAsync();
+    var balance = rec["b"].As<long>();
+    if (balance < amount) throw new InvalidOperationException("insufficient funds");
+
+    await tx.RunAsync("MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt",
+                      new { id = fromId, amt = amount });
+    await tx.RunAsync("MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt",
+                      new { id = toId,   amt = amount });
+});
+```
+
+Transaction callbacks must be idempotent — the driver retries on transient failures.

--- a/neo4j-driver-skill/references/dotnet.md
+++ b/neo4j-driver-skill/references/dotnet.md
@@ -16,9 +16,7 @@ await driver.VerifyConnectivityAsync();
 var result = await driver
     .ExecutableQuery("MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
     .WithParameters(new { name = "Alice" })
-    .WithConfig(new QueryConfig(
-        database: "neo4j",
-        routing: RoutingControl.Readers))
+    .WithConfig(new QueryConfig(routing: RoutingControl.Readers))
     .ExecuteAsync();
 
 foreach (var record in result.Result)
@@ -42,7 +40,6 @@ foreach (var record in result.Result)
 ```csharp
 var names = await driver
     .ExecutableQuery("MATCH (p:Person) RETURN p.name AS name")
-    .WithConfig(new QueryConfig(database: "neo4j"))
     .WithMap(r => r["name"].As<string>())
     .ExecuteAsync();
 // names.Result is IReadOnlyList<string>
@@ -59,14 +56,13 @@ var rows = new[] {
 await driver
     .ExecutableQuery("UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
     .WithParameters(new { rows })
-    .WithConfig(new QueryConfig(database: "neo4j"))
     .ExecuteAsync();
 ```
 
 ## When to drop to a session
 
 ```csharp
-await using var session = driver.AsyncSession(o => o.WithDatabase("neo4j"));
+await using var session = driver.AsyncSession();
 
 await session.ExecuteWriteAsync(async tx =>
 {

--- a/neo4j-driver-skill/references/go.md
+++ b/neo4j-driver-skill/references/go.md
@@ -1,0 +1,90 @@
+# Go driver (`github.com/neo4j/neo4j-go-driver/v6`)
+
+Install: `go get github.com/neo4j/neo4j-go-driver/v6/neo4j`.
+
+## Canonical example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/neo4j/neo4j-go-driver/v6/neo4j"
+)
+
+func main() {
+    ctx := context.Background()
+
+    driver, err := neo4j.NewDriverWithContext(
+        "neo4j://localhost:7687",
+        neo4j.BasicAuth("neo4j", "password", ""))
+    if err != nil { panic(err) }
+    defer driver.Close(ctx)
+
+    if err := driver.VerifyConnectivity(ctx); err != nil { panic(err) }
+
+    result, err := neo4j.ExecuteQuery(ctx, driver,
+        "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
+        map[string]any{"name": "Alice"},
+        neo4j.EagerResultTransformer,
+        neo4j.ExecuteQueryWithDatabase("neo4j"),
+        neo4j.ExecuteQueryWithReadersRouting(),
+    )
+    if err != nil { panic(err) }
+
+    for _, r := range result.Records {
+        fmt.Println(r.AsMap())   // map[string]any
+    }
+}
+```
+
+## Accessing fields
+
+- `record.Get("name")` → `(any, bool)`
+- `record.AsMap()` → `map[string]any` for the whole record
+- `record.Keys` — column names
+- `neo4j.GetRecordValue[T](record, "name")` for typed extraction (v6)
+
+## Bulk writes
+
+```go
+rows := []map[string]any{
+    {"id": 1, "name": "Alice"},
+    {"id": 2, "name": "Bob"},
+}
+neo4j.ExecuteQuery(ctx, driver,
+    "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
+    map[string]any{"rows": rows},
+    neo4j.EagerResultTransformer,
+    neo4j.ExecuteQueryWithDatabase("neo4j"))
+```
+
+## Configuration options
+
+- `ExecuteQueryWithDatabase("neo4j")` — required in practice
+- `ExecuteQueryWithReadersRouting()` / `ExecuteQueryWithWritersRouting()`
+- `ExecuteQueryWithImpersonatedUser("alice")`
+- `ExecuteQueryWithBookmarkManager(bm)`
+
+## When to drop to a session
+
+```go
+session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "neo4j"})
+defer session.Close(ctx)
+
+_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+    r, err := tx.Run(ctx,
+        "MATCH (a:Account {id:$id}) RETURN a.balance AS b",
+        map[string]any{"id": fromId})
+    if err != nil { return nil, err }
+    rec, err := r.Single(ctx)
+    if err != nil { return nil, err }
+    balance, _ := rec.Get("b")
+    if balance.(int64) < amount { return nil, fmt.Errorf("insufficient funds") }
+    // ... two more tx.Run calls ...
+    return nil, nil
+})
+```
+
+Transaction callbacks must be idempotent — the driver retries on transient failures.

--- a/neo4j-driver-skill/references/go.md
+++ b/neo4j-driver-skill/references/go.md
@@ -28,6 +28,7 @@ func main() {
         "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
         map[string]any{"name": "Alice"},
         neo4j.EagerResultTransformer,
+        neo4j.ExecuteQueryWithDatabase("neo4j"),
         neo4j.ExecuteQueryWithReadersRouting(),
     )
     if err != nil { panic(err) }
@@ -55,20 +56,21 @@ rows := []map[string]any{
 neo4j.ExecuteQuery(ctx, driver,
     "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
     map[string]any{"rows": rows},
-    neo4j.EagerResultTransformer)
+    neo4j.EagerResultTransformer,
+    neo4j.ExecuteQueryWithDatabase("neo4j"))
 ```
 
 ## Configuration options
 
+- `ExecuteQueryWithDatabase("neo4j")` — set it explicitly to avoid the home-database round-trip
 - `ExecuteQueryWithReadersRouting()` / `ExecuteQueryWithWritersRouting()`
 - `ExecuteQueryWithImpersonatedUser("alice")`
 - `ExecuteQueryWithBookmarkManager(bm)`
-- `ExecuteQueryWithDatabase("name")` — only when targeting a non-default database
 
 ## When to drop to a session
 
 ```go
-session := driver.NewSession(ctx, neo4j.SessionConfig{})
+session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "neo4j"})
 defer session.Close(ctx)
 
 _, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {

--- a/neo4j-driver-skill/references/go.md
+++ b/neo4j-driver-skill/references/go.md
@@ -28,7 +28,6 @@ func main() {
         "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
         map[string]any{"name": "Alice"},
         neo4j.EagerResultTransformer,
-        neo4j.ExecuteQueryWithDatabase("neo4j"),
         neo4j.ExecuteQueryWithReadersRouting(),
     )
     if err != nil { panic(err) }
@@ -56,21 +55,20 @@ rows := []map[string]any{
 neo4j.ExecuteQuery(ctx, driver,
     "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
     map[string]any{"rows": rows},
-    neo4j.EagerResultTransformer,
-    neo4j.ExecuteQueryWithDatabase("neo4j"))
+    neo4j.EagerResultTransformer)
 ```
 
 ## Configuration options
 
-- `ExecuteQueryWithDatabase("neo4j")` — required in practice
 - `ExecuteQueryWithReadersRouting()` / `ExecuteQueryWithWritersRouting()`
 - `ExecuteQueryWithImpersonatedUser("alice")`
 - `ExecuteQueryWithBookmarkManager(bm)`
+- `ExecuteQueryWithDatabase("name")` — only when targeting a non-default database
 
 ## When to drop to a session
 
 ```go
-session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "neo4j"})
+session := driver.NewSession(ctx, neo4j.SessionConfig{})
 defer session.Close(ctx)
 
 _, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {

--- a/neo4j-driver-skill/references/java.md
+++ b/neo4j-driver-skill/references/java.md
@@ -11,6 +11,7 @@ import org.neo4j.driver.EagerResult;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.QueryConfig;
 import org.neo4j.driver.RoutingControl;
+import org.neo4j.driver.SessionConfig;
 import java.util.Map;
 
 try (Driver driver = GraphDatabase.driver(
@@ -23,6 +24,7 @@ try (Driver driver = GraphDatabase.driver(
             "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
         .withParameters(Map.of("name", "Alice"))
         .withConfig(QueryConfig.builder()
+            .withDatabase("neo4j")
             .withRouting(RoutingControl.READ)
             .build())
         .execute();
@@ -51,13 +53,14 @@ var rows = List.of(
 driver.executableQuery(
         "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
     .withParameters(Map.of("rows", rows))
+    .withConfig(QueryConfig.builder().withDatabase("neo4j").build())
     .execute();
 ```
 
 ## When to drop to a session
 
 ```java
-try (var session = driver.session()) {
+try (var session = driver.session(SessionConfig.forDatabase("neo4j"))) {
     session.executeWrite(tx -> {
         var balance = tx.run(
             "MATCH (a:Account {id:$id}) RETURN a.balance AS b",

--- a/neo4j-driver-skill/references/java.md
+++ b/neo4j-driver-skill/references/java.md
@@ -1,0 +1,78 @@
+# Java driver (`org.neo4j.driver:neo4j-java-driver`)
+
+Maven: `org.neo4j.driver:neo4j-java-driver`. JDK 17+ for driver 6.x.
+
+## Canonical example
+
+```java
+import org.neo4j.driver.*;
+import java.util.Map;
+
+try (Driver driver = GraphDatabase.driver(
+        "neo4j://localhost:7687",
+        AuthTokens.basic("neo4j", "password"))) {
+
+    driver.verifyConnectivity();
+
+    EagerResult result = driver.executableQuery(
+            "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
+        .withParameters(Map.of("name", "Alice"))
+        .withConfig(QueryConfig.builder()
+            .withDatabase("neo4j")
+            .withRouting(RoutingControl.READ)
+            .build())
+        .execute();
+
+    result.records().forEach(r -> {
+        Map<String, Object> row = r.asMap();   // plain Map
+    });
+}
+```
+
+`EagerResult` exposes `records()`, `summary()`, `keys()`.
+
+## Accessing fields
+
+- `record.get("name").asString()` / `.asInt()` / `.asLong()` / `.asDouble()` / `.asBoolean()` / `.asList()` / `.asMap()`
+- `record.asMap()` — whole record as `Map<String,Object>` (values unwrapped to Java types)
+- `record.keys()` — list of column names
+
+## Bulk writes
+
+```java
+var rows = List.of(
+    Map.of("id", 1, "name", "Alice"),
+    Map.of("id", 2, "name", "Bob"));
+
+driver.executableQuery(
+        "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
+    .withParameters(Map.of("rows", rows))
+    .withConfig(QueryConfig.builder().withDatabase("neo4j").build())
+    .execute();
+```
+
+## When to drop to a session
+
+```java
+try (var session = driver.session(SessionConfig.forDatabase("neo4j"))) {
+    session.executeWrite(tx -> {
+        var balance = tx.run(
+            "MATCH (a:Account {id:$id}) RETURN a.balance AS b",
+            Map.of("id", fromId)
+        ).single().get("b").asLong();
+        if (balance < amount) throw new RuntimeException("insufficient funds");
+        tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt",
+               Map.of("id", fromId, "amt", amount));
+        tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt",
+               Map.of("id", toId,   "amt", amount));
+        return null;
+    });
+}
+```
+
+Transaction lambdas must be idempotent — the driver retries on transient failures.
+
+## Reactive / async
+
+- Async: `driver.executableQuery(...).executeAsync()` returns `CompletionStage<EagerResult>`.
+- Reactive: `driver.session(ReactiveSession.class)` for back-pressured streaming.

--- a/neo4j-driver-skill/references/java.md
+++ b/neo4j-driver-skill/references/java.md
@@ -5,7 +5,12 @@ Maven: `org.neo4j.driver:neo4j-java-driver`. JDK 17+ for driver 6.x.
 ## Canonical example
 
 ```java
-import org.neo4j.driver.*;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.EagerResult;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.QueryConfig;
+import org.neo4j.driver.RoutingControl;
 import java.util.Map;
 
 try (Driver driver = GraphDatabase.driver(
@@ -18,7 +23,6 @@ try (Driver driver = GraphDatabase.driver(
             "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age")
         .withParameters(Map.of("name", "Alice"))
         .withConfig(QueryConfig.builder()
-            .withDatabase("neo4j")
             .withRouting(RoutingControl.READ)
             .build())
         .execute();
@@ -47,14 +51,13 @@ var rows = List.of(
 driver.executableQuery(
         "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row")
     .withParameters(Map.of("rows", rows))
-    .withConfig(QueryConfig.builder().withDatabase("neo4j").build())
     .execute();
 ```
 
 ## When to drop to a session
 
 ```java
-try (var session = driver.session(SessionConfig.forDatabase("neo4j"))) {
+try (var session = driver.session()) {
     session.executeWrite(tx -> {
         var balance = tx.run(
             "MATCH (a:Account {id:$id}) RETURN a.balance AS b",

--- a/neo4j-driver-skill/references/javascript.md
+++ b/neo4j-driver-skill/references/javascript.md
@@ -1,0 +1,91 @@
+# JavaScript / TypeScript driver (`neo4j-driver`)
+
+Install: `npm install neo4j-driver`.
+
+## Canonical example
+
+```javascript
+import neo4j from 'neo4j-driver'
+
+const driver = neo4j.driver(
+  'neo4j://localhost:7687',
+  neo4j.auth.basic('neo4j', 'password')
+)
+
+try {
+  await driver.verifyConnectivity()
+
+  const { records, summary } = await driver.executeQuery(
+    'MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age',
+    { name: 'Alice' },
+    { database: 'neo4j', routing: neo4j.routing.READ }
+  )
+
+  const rows = records.map(r => r.toObject())   // array of plain objects
+} finally {
+  await driver.close()
+}
+```
+
+Signature: `driver.executeQuery(cypher, params, { database, routing, impersonatedUser, auth, bookmarkManager, resultTransformer })`.
+
+## Accessing fields
+
+- `record.get('name')` — one field
+- `record.toObject()` — whole record as plain object
+- `record.keys` — array of column names
+
+## Bulk writes
+
+```javascript
+await driver.executeQuery(
+  'UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row',
+  { rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] },
+  { database: 'neo4j' }
+)
+```
+
+## Integers
+
+Neo4j integers are 64-bit; JS numbers are 53-bit. Default return is a `neo4j.Integer`. For the common case where values fit in `Number`:
+
+```javascript
+const driver = neo4j.driver(uri, auth, { disableLosslessIntegers: true })
+```
+
+Otherwise convert explicitly with `value.toNumber()` or `value.toString()`.
+
+## Result transformers
+
+```javascript
+const { resultTransformers } = neo4j
+
+const people = await driver.executeQuery(
+  'MATCH (p:Person) RETURN p.name AS name',
+  {},
+  { database: 'neo4j',
+    resultTransformer: resultTransformers.mappedResultTransformer({
+      map: record => record.toObject()
+    })
+  }
+)
+```
+
+## When to drop to a session
+
+```javascript
+const session = driver.session({ database: 'neo4j' })
+try {
+  await session.executeWrite(async tx => {
+    const r = await tx.run('MATCH (a:Account {id:$id}) RETURN a.balance AS b', { id: from })
+    const balance = r.records[0].get('b').toNumber()
+    if (balance < amount) throw new Error('insufficient funds')
+    await tx.run('MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt', { id: from, amt: amount })
+    await tx.run('MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt', { id: to,   amt: amount })
+  })
+} finally {
+  await session.close()
+}
+```
+
+Transaction callbacks must be idempotent — the driver retries on transient failures.

--- a/neo4j-driver-skill/references/javascript.md
+++ b/neo4j-driver-skill/references/javascript.md
@@ -18,7 +18,7 @@ try {
   const { records, summary } = await driver.executeQuery(
     'MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age',
     { name: 'Alice' },
-    { routing: neo4j.routing.READ }
+    { database: 'neo4j', routing: neo4j.routing.READ }
   )
 
   const rows = records.map(r => r.toObject())   // array of plain objects
@@ -27,7 +27,7 @@ try {
 }
 ```
 
-Signature: `driver.executeQuery(cypher, params, { routing, database, impersonatedUser, auth, bookmarkManager, resultTransformer })`.
+Signature: `driver.executeQuery(cypher, params, { database, routing, impersonatedUser, auth, bookmarkManager, resultTransformer })`.
 
 ## Accessing fields
 
@@ -40,19 +40,45 @@ Signature: `driver.executeQuery(cypher, params, { routing, database, impersonate
 ```javascript
 await driver.executeQuery(
   'UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row',
-  { rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+  { rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] },
+  { database: 'neo4j' }
 )
 ```
 
 ## Integers
 
-Neo4j integers are 64-bit; JS numbers are 53-bit. Default return is a `neo4j.Integer`. For the common case where values fit in `Number`:
+Neo4j's `INTEGER` is 64-bit; a plain JS `Number` is 53-bit. Integer handling works differently on **results** vs **parameters**, and the driver-level config options only affect results.
+
+### Results (reading INTEGER columns)
+
+By default the driver returns integer-typed columns as its own `neo4j.Integer` class, so precision is never silently lost. Two driver options change that:
 
 ```javascript
+// return JS Number — lossless only when values fit in 53 bits
 const driver = neo4j.driver(uri, auth, { disableLosslessIntegers: true })
+
+// return native BigInt — lossless for all 64-bit ints (takes precedence over disableLosslessIntegers)
+const driver = neo4j.driver(uri, auth, { useBigInt: true })
 ```
 
-Otherwise convert explicitly with `value.toNumber()` or `value.toString()`.
+With neither option, convert explicitly: `value.toNumber()` or `value.toString()`.
+
+### Parameters (writing values into a query)
+
+**Neither `disableLosslessIntegers` nor `useBigInt` change parameter encoding.** A plain JS `Number` is always sent as a Cypher `FLOAT`, even when its value looks like an integer — so `{ id: 12345 }` arrives on the server as `12345.0`. Symptoms: IDs rendering as `12345.0` in Browser, and `WHERE n.id = $id` failing to match nodes whose `id` was stored as INTEGER.
+
+To send a Cypher `INTEGER`, wrap the value:
+
+```javascript
+await driver.executeQuery(
+  'MATCH (u:User {id: $id}) RETURN u',
+  { id: neo4j.int(12345) },   // INTEGER — matches stored INTEGER ids
+  { database: 'neo4j' }
+)
+```
+
+- `neo4j.int(value)` — preferred. Accepts a `Number`, a `string` (use for values outside ±2^53), or another `Integer`.
+- `BigInt(value)` — also accepted and sent as INTEGER.
 
 ## Result transformers
 
@@ -62,7 +88,7 @@ const { resultTransformers } = neo4j
 const people = await driver.executeQuery(
   'MATCH (p:Person) RETURN p.name AS name',
   {},
-  {
+  { database: 'neo4j',
     resultTransformer: resultTransformers.mappedResultTransformer({
       map: record => record.toObject()
     })
@@ -73,7 +99,7 @@ const people = await driver.executeQuery(
 ## When to drop to a session
 
 ```javascript
-const session = driver.session()
+const session = driver.session({ database: 'neo4j' })
 try {
   await session.executeWrite(async tx => {
     const r = await tx.run('MATCH (a:Account {id:$id}) RETURN a.balance AS b', { id: from })

--- a/neo4j-driver-skill/references/javascript.md
+++ b/neo4j-driver-skill/references/javascript.md
@@ -18,7 +18,7 @@ try {
   const { records, summary } = await driver.executeQuery(
     'MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age',
     { name: 'Alice' },
-    { database: 'neo4j', routing: neo4j.routing.READ }
+    { routing: neo4j.routing.READ }
   )
 
   const rows = records.map(r => r.toObject())   // array of plain objects
@@ -27,7 +27,7 @@ try {
 }
 ```
 
-Signature: `driver.executeQuery(cypher, params, { database, routing, impersonatedUser, auth, bookmarkManager, resultTransformer })`.
+Signature: `driver.executeQuery(cypher, params, { routing, database, impersonatedUser, auth, bookmarkManager, resultTransformer })`.
 
 ## Accessing fields
 
@@ -40,8 +40,7 @@ Signature: `driver.executeQuery(cypher, params, { database, routing, impersonate
 ```javascript
 await driver.executeQuery(
   'UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row',
-  { rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] },
-  { database: 'neo4j' }
+  { rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
 )
 ```
 
@@ -63,7 +62,7 @@ const { resultTransformers } = neo4j
 const people = await driver.executeQuery(
   'MATCH (p:Person) RETURN p.name AS name',
   {},
-  { database: 'neo4j',
+  {
     resultTransformer: resultTransformers.mappedResultTransformer({
       map: record => record.toObject()
     })
@@ -74,7 +73,7 @@ const people = await driver.executeQuery(
 ## When to drop to a session
 
 ```javascript
-const session = driver.session({ database: 'neo4j' })
+const session = driver.session()
 try {
   await session.executeWrite(async tx => {
     const r = await tx.run('MATCH (a:Account {id:$id}) RETURN a.balance AS b', { id: from })

--- a/neo4j-driver-skill/references/python.md
+++ b/neo4j-driver-skill/references/python.md
@@ -1,0 +1,89 @@
+# Python driver (`neo4j`)
+
+Install: `pip install neo4j`. For 3–10× speedup with the same API, install `neo4j-rust-ext`.
+
+## Canonical example
+
+```python
+from neo4j import GraphDatabase, RoutingControl
+
+URI = "neo4j://localhost:7687"
+AUTH = ("neo4j", "password")
+
+with GraphDatabase.driver(URI, auth=AUTH) as driver:
+    driver.verify_connectivity()
+
+    records, summary, keys = driver.execute_query(
+        "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
+        name="Alice",
+        database_="neo4j",
+        routing_=RoutingControl.READ,   # or the string "r"
+    )
+
+    rows = [r.data() for r in records]   # list[dict] — JSON-friendly
+```
+
+`execute_query` returns an `EagerResult` unpackable as `(records, summary, keys)`.
+
+## Parameters
+
+Pass as kwargs (any name not ending in `_`) or as `parameters_={...}`:
+
+```python
+driver.execute_query("MERGE (:Person {name: $name})", name="Alice", database_="neo4j")
+driver.execute_query("MERGE (:Person {name: $name})", parameters_={"name": "Alice"}, database_="neo4j")
+```
+
+Config kwargs end in `_`: `database_`, `routing_`, `auth_`, `impersonated_user_`, `result_transformer_`, `bookmark_manager_`.
+
+## Bulk writes — one round-trip
+
+```python
+driver.execute_query(
+    "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
+    rows=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+    database_="neo4j",
+)
+```
+
+## Result transformers
+
+```python
+import neo4j
+
+df = driver.execute_query(
+    "MATCH (p:Person) RETURN p.name AS name, p.age AS age",
+    database_="neo4j",
+    result_transformer_=neo4j.Result.to_df,      # pandas DataFrame
+)
+
+graph = driver.execute_query(
+    "MATCH (a)-[r]->(b) RETURN a, r, b",
+    database_="neo4j",
+    result_transformer_=neo4j.Result.graph,      # nodes + relationships
+)
+```
+
+A transformer receives a `Result` and must not return it — consume it (`result.single()`, `list(result)`, etc.).
+
+## When to drop to a session
+
+Use only when you need multiple queries + client logic in **one** transaction, or want to stream large results:
+
+```python
+def transfer(tx, from_id, to_id, amount):
+    balance = tx.run("MATCH (a:Account {id:$id}) RETURN a.balance AS b", id=from_id).single()["b"]
+    if balance < amount:
+        raise ValueError("insufficient funds")
+    tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt", id=from_id, amt=amount)
+    tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt", id=to_id,   amt=amount)
+
+with driver.session(database="neo4j") as session:
+    session.execute_write(transfer, 1, 2, 100)
+```
+
+The transaction function **must be idempotent** — the driver retries on transient failures.
+
+## Async
+
+`from neo4j import AsyncGraphDatabase` — same API with `await`, `async with`, `async for`.

--- a/neo4j-driver-skill/references/python.md
+++ b/neo4j-driver-skill/references/python.md
@@ -16,6 +16,7 @@ with GraphDatabase.driver(URI, auth=AUTH) as driver:
     records, summary, keys = driver.execute_query(
         "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
         name="Alice",
+        database_="neo4j",
         routing_=RoutingControl.READ,   # or the string "r"
     )
 
@@ -23,17 +24,32 @@ with GraphDatabase.driver(URI, auth=AUTH) as driver:
         name, age = r["name"], r["age"]
 ```
 
-`execute_query` returns an `EagerResult` unpackable as `(records, summary, keys)`. Access fields by key (`r["name"]`) or index (`r[0]`).
+By default `execute_query` returns an `EagerResult` unpackable as `(records, summary, keys)`. Access fields by key (`r["name"]`) or index (`r[0]`). When `result_transformer_` is set, the call returns whatever the transformer returns instead.
 
 `record.data()` returns a `dict` of the whole record and is handy for prototyping or interactive sessions — the Python driver docs explicitly call it "convenient but opinionated", not a general-purpose serializer. It materializes every field, flattens `Node`/`Relationship`/`Path` into nested dicts/lists (losing type info), and leaves temporal types as driver objects. Prefer reading the fields you need; reach for `.data()` only when that trade-off is fine.
+
+If you do want `.data()` semantics, skip the list comprehension and pass `Result.data` as the transformer — one pass, no intermediate `Record` list:
+
+```python
+from neo4j import GraphDatabase, Result, RoutingControl
+
+rows, summary, keys = driver.execute_query(
+    "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
+    name="Alice",
+    database_="neo4j",
+    routing_=RoutingControl.READ,
+    result_transformer_=Result.data,
+)
+# rows is list[dict]
+```
 
 ## Parameters
 
 Pass as kwargs (any name not ending in `_`) or as `parameters_={...}`:
 
 ```python
-driver.execute_query("MERGE (:Person {name: $name})", name="Alice")
-driver.execute_query("MERGE (:Person {name: $name})", parameters_={"name": "Alice"})
+driver.execute_query("MERGE (:Person {name: $name})", name="Alice", database_="neo4j")
+driver.execute_query("MERGE (:Person {name: $name})", parameters_={"name": "Alice"}, database_="neo4j")
 ```
 
 Config kwargs end in `_`: `database_`, `routing_`, `auth_`, `impersonated_user_`, `result_transformer_`, `bookmark_manager_`.
@@ -44,6 +60,7 @@ Config kwargs end in `_`: `database_`, `routing_`, `auth_`, `impersonated_user_`
 driver.execute_query(
     "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
     rows=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+    database_="neo4j",
 )
 ```
 
@@ -54,11 +71,13 @@ import neo4j
 
 df = driver.execute_query(
     "MATCH (p:Person) RETURN p.name AS name, p.age AS age",
+    database_="neo4j",
     result_transformer_=neo4j.Result.to_df,      # pandas DataFrame
 )
 
 graph = driver.execute_query(
     "MATCH (a)-[r]->(b) RETURN a, r, b",
+    database_="neo4j",
     result_transformer_=neo4j.Result.graph,      # nodes + relationships
 )
 ```
@@ -77,7 +96,7 @@ def transfer(tx, from_id, to_id, amount):
     tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt", id=from_id, amt=amount)
     tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt", id=to_id,   amt=amount)
 
-with driver.session() as session:
+with driver.session(database="neo4j") as session:
     session.execute_write(transfer, 1, 2, 100)
 ```
 

--- a/neo4j-driver-skill/references/python.md
+++ b/neo4j-driver-skill/references/python.md
@@ -16,22 +16,24 @@ with GraphDatabase.driver(URI, auth=AUTH) as driver:
     records, summary, keys = driver.execute_query(
         "MATCH (p:Person {name: $name}) RETURN p.name AS name, p.age AS age",
         name="Alice",
-        database_="neo4j",
         routing_=RoutingControl.READ,   # or the string "r"
     )
 
-    rows = [r.data() for r in records]   # list[dict] — JSON-friendly
+    for r in records:
+        name, age = r["name"], r["age"]
 ```
 
-`execute_query` returns an `EagerResult` unpackable as `(records, summary, keys)`.
+`execute_query` returns an `EagerResult` unpackable as `(records, summary, keys)`. Access fields by key (`r["name"]`) or index (`r[0]`).
+
+`record.data()` returns a `dict` of the whole record and is handy for prototyping or interactive sessions — the Python driver docs explicitly call it "convenient but opinionated", not a general-purpose serializer. It materializes every field, flattens `Node`/`Relationship`/`Path` into nested dicts/lists (losing type info), and leaves temporal types as driver objects. Prefer reading the fields you need; reach for `.data()` only when that trade-off is fine.
 
 ## Parameters
 
 Pass as kwargs (any name not ending in `_`) or as `parameters_={...}`:
 
 ```python
-driver.execute_query("MERGE (:Person {name: $name})", name="Alice", database_="neo4j")
-driver.execute_query("MERGE (:Person {name: $name})", parameters_={"name": "Alice"}, database_="neo4j")
+driver.execute_query("MERGE (:Person {name: $name})", name="Alice")
+driver.execute_query("MERGE (:Person {name: $name})", parameters_={"name": "Alice"})
 ```
 
 Config kwargs end in `_`: `database_`, `routing_`, `auth_`, `impersonated_user_`, `result_transformer_`, `bookmark_manager_`.
@@ -42,7 +44,6 @@ Config kwargs end in `_`: `database_`, `routing_`, `auth_`, `impersonated_user_`
 driver.execute_query(
     "UNWIND $rows AS row MERGE (p:Person {id: row.id}) SET p += row",
     rows=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
-    database_="neo4j",
 )
 ```
 
@@ -53,13 +54,11 @@ import neo4j
 
 df = driver.execute_query(
     "MATCH (p:Person) RETURN p.name AS name, p.age AS age",
-    database_="neo4j",
     result_transformer_=neo4j.Result.to_df,      # pandas DataFrame
 )
 
 graph = driver.execute_query(
     "MATCH (a)-[r]->(b) RETURN a, r, b",
-    database_="neo4j",
     result_transformer_=neo4j.Result.graph,      # nodes + relationships
 )
 ```
@@ -78,7 +77,7 @@ def transfer(tx, from_id, to_id, amount):
     tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance - $amt", id=from_id, amt=amount)
     tx.run("MATCH (a:Account {id:$id}) SET a.balance = a.balance + $amt", id=to_id,   amt=amount)
 
-with driver.session(database="neo4j") as session:
+with driver.session() as session:
     session.execute_write(transfer, 1, 2, 100)
 ```
 


### PR DESCRIPTION
Covers the execute_query API across all five official Neo4j drivers (Python, JavaScript, Java, Go, .NET) with per-language references for canonical usage, record-to-map conversion, bulk writes via UNWIND, and guidance on when to drop to session.execute_read/write.