### PR TITLE
Add neo4j-cypher-25-skill for Cypher 5 vs Cypher 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Assists with upgrading Cypher queries to newer Neo4j versions.
 - Migrating databases from Neo4j 4.x or 5.x to 2025.x or 2026.x
 - Updating Cypher queries to a newer major Neo4j version
 
+### neo4j-cypher-25-skill
+
+Covers the split between Cypher 5 and Cypher 25 introduced in Neo4j 2025.06: version selector, breaking changes, and new features.
+
+**Use this skill when:**
+- Writing queries against Neo4j 2025.06+ and choosing a Cypher version
+- Migrating queries from Cypher 5 to Cypher 25
+- Diagnosing a query that fails after the default language changed
+
 ## Installation
 
 ### Using npx skills (Recommended)
@@ -70,6 +79,7 @@ git clone https://github.com/neo4j-contrib/neo4j-skills.git
 ln -s $(pwd)/neo4j-skills/neo4j-cypher-skill ~/.claude/skills/
 ln -s $(pwd)/neo4j-skills/neo4j-migration-skill ~/.claude/skills/
 ln -s $(pwd)/neo4j-skills/neo4j-cli-tools-skill ~/.claude/skills/
+ln -s $(pwd)/neo4j-skills/neo4j-cypher-25-skill ~/.claude/skills/
 ```
 
 #### For other agents:

--- a/neo4j-cypher-25-skill/SKILL.md
+++ b/neo4j-cypher-25-skill/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: neo4j-cypher-25-skill
+description: Use when writing, reviewing, or migrating Cypher queries between Cypher 5 and Cypher 25 on Neo4j 2025.06+. Covers the version selector, breaking changes, and new features.
+allowed-tools: WebFetch
+---
+
+# Cypher 5 vs Cypher 25 skill
+
+Since Neo4j 2025.06, Cypher is versioned **independently** of the server. Two languages coexist:
+
+- **Cypher 5** — frozen. Bug fixes and perf only, no new features. Supported for at least two more LTS cycles (~5–6 years).
+- **Cypher 25** — the evolving language. All new Cypher features (vector type, conditional subqueries, `LET`/`NEXT`/`FILTER`, walk semantics, etc.) land here only. Guaranteed additive from 2025.06 onward.
+
+From Neo4j 2026.02, Cypher 25 is the **default** for new databases. Existing databases upgraded from earlier versions stay on Cypher 5 until you opt in.
+
+## When to use
+
+Use this skill when:
+- the user asks about Cypher 25, Cypher 5, version selectors, or `CYPHER 25`/`CYPHER 5` prefixes
+- migrating queries from Cypher 5 to Cypher 25
+- a query fails with a version-related error (e.g. `SET n = r` rejected, unknown function)
+- deciding which language to default a new database to
+
+## Version selector
+
+**Per query** (overrides the database default):
+
+```cypher
+CYPHER 25
+MATCH (p:Person {name: $name}) RETURN p
+```
+
+```cypher
+CYPHER 5
+MATCH (p:Person {name: $name}) RETURN p
+```
+
+Can be combined with other options: `CYPHER 25 runtime=parallel MATCH ...`.
+
+**Per database**:
+
+```cypher
+CREATE DATABASE analytics SET DEFAULT LANGUAGE CYPHER 25;
+ALTER  DATABASE analytics SET DEFAULT LANGUAGE CYPHER 25;
+```
+
+**Server-wide default** (2026.02+): `db.query.default_language=CYPHER_25` in `neo4j.conf`.
+
+**Check a database's language**: `SHOW DATABASES YIELD name, currentPrimariesCount, defaultLanguage`.
+
+## The handful of breaking changes a Cypher-5 query will hit
+
+These are the ones that make an existing query fail under `CYPHER 25`:
+
+1. **`SET n = r` is no longer allowed** (where `r` is a node/relationship on the right). Use `SET n = properties(r)`.
+2. **`MERGE` can no longer reference one pattern entity's property from another** in the same `MERGE`. Example that now fails: `MERGE (a {foo:1})-[:T]->(b {foo:a.foo})`. Split into two `MERGE` statements.
+3. **Composite-database graph references must be fully quoted as one token**: `` USE `composite.sub1` `` — not `` USE composite.`sub1` ``.
+4. **Unicode in unescaped identifiers is rejected** (`\u0085`, `\u0024`, etc.). Wrap the identifier in backticks or rename it.
+5. **`indexProvider` in `OPTIONS {…}` on `CREATE INDEX`/constraint is gone.** Drop it.
+6. **Removed procedures** — replace calls to:
+   - `db.create.setVectorProperty()` → `SET n.embedding = vector($values, $dim, FLOAT32)`
+   - `db.index.vector.createNodeIndex()` → `CREATE VECTOR INDEX … FOR (n:Label) ON n.prop …`
+   - `dbms.upgrade()`, `dbms.upgradeStatus()`, `dbms.quarantineDatabase()`, `dbms.cluster.readReplicaToggle()`, `dbms.cluster.uncordonServer()` — no direct replacement; handled by modern admin tooling.
+7. **Impossible `REVOKE` statements now error** instead of silently returning a notification.
+
+Full enumerated list: [references/breaking-changes.md](references/breaking-changes.md).
+
+## The Cypher 25 features worth reaching for
+
+- **Vector type and functions**: `VECTOR([1.0, 2.0, 3.0], 3, FLOAT32)`, `vector_distance()`, `vector_norm()`, `vector_dimension_count()`. Vector indexes now support multiple labels and extra filter properties.
+- **Dynamic labels/types**: `MATCH (n:$(labelVar))` / `MERGE ()-[:$(typeVar)]->()` instead of APOC for the common case.
+- **Conditional subqueries**: `CALL { WHEN cond THEN … ELSE … }` for branching updates.
+- **Collection functions** (namespaced): `coll.sort()`, `coll.distinct()`, `coll.flatten()`, `coll.max()`, `coll.min()`, `coll.indexOf()`, `coll.insert()`, `coll.remove()`.
+- **GQL-flavored composition**: `LET x = …`, `NEXT`, `FILTER`, `RETURN ALL`.
+- **Walk semantics**: `MATCH REPEATABLE ELEMENTS …` lets a path reuse relationships; `DIFFERENT RELATIONSHIPS` is the Cypher-5-equivalent default.
+- **Temporal `format(temporal, pattern)`** for dynamic formatting instead of `toString()` tricks.
+- **Read → write transitions no longer need `WITH`**: `MATCH (p:Person) CREATE (p)-[:HAS]->(:Thing)` is accepted directly.
+- **Parameters in more places**: numeric-leading names (`$0hello`), inside `SHORTEST` / `ANY` path selectors.
+- **New constraint kinds**: `NODE_LABEL_EXISTENCE`, `RELATIONSHIP_SOURCE_LABEL`, `RELATIONSHIP_TARGET_LABEL`.
+
+Full additions list and examples: [references/new-features.md](references/new-features.md).
+
+## Instructions
+
+When asked to migrate Cypher 5 → Cypher 25:
+
+1. **Decide scope**: whole database (flip default with `ALTER DATABASE`) vs selected queries (prepend `CYPHER 25`).
+2. **Grep the codebase / queries** for the breaking patterns above. The highest-hit ones in practice:
+   - `SET\s+\w+\s*=\s*\w+\s*$` (plain `SET a = b` where b could be a node/rel)
+   - `MERGE` patterns with cross-entity property references
+   - `OPTIONS\s*{[^}]*indexProvider`
+   - Calls to the removed procedures listed above
+3. **For each break, apply the fix** from the breaking-changes list — do not just pin to `CYPHER 5`; that blocks future features.
+4. **Recommend opt-in new features** only when they simplify existing code (dynamic labels replacing APOC, vector type replacing `db.create.setVectorProperty`). Don't rewrite working code for novelty.
+5. **Verify** with `EXPLAIN CYPHER 25 <query>` — it will surface any remaining syntax rejections without executing.
+
+When writing fresh Cypher for 2025.06+: default to Cypher 25.
+
+## Resources
+
+- [Cypher version selection](https://neo4j.com/docs/cypher-manual/current/queries/select-version/)
+- [Cypher additions, deprecations, removals](https://neo4j.com/docs/cypher-manual/current/deprecations-additions-removals-compatibility/)
+- [Cypher versioning blog post](https://neo4j.com/blog/developer/cypher-versioning/)
+- [Default-language server config](https://neo4j.com/docs/operations-manual/current/configuration/cypher-version-configuration/)
+- [Cypher 25 cheat sheet](https://neo4j.com/docs/cypher-cheat-sheet/25/all/)

--- a/neo4j-cypher-25-skill/references/breaking-changes.md
+++ b/neo4j-cypher-25-skill/references/breaking-changes.md
@@ -1,0 +1,90 @@
+# Cypher 25 breaking changes (vs Cypher 5)
+
+These are the items **removed** or **tightened** in Cypher 25. A query that depends on any of them will fail under `CYPHER 25`.
+
+## Syntax removals
+
+### `SET node = relationship` / `SET node = node` (right-hand side as entity)
+
+Wrap the RHS in `properties()`.
+
+```cypher
+// Cypher 5 (still works there)
+MATCH (n:Order)-[r:SHIPPED_TO]->(:Address)
+SET n = r
+
+// Cypher 25
+MATCH (n:Order)-[r:SHIPPED_TO]->(:Address)
+SET n = properties(r)
+```
+
+### Cross-entity property references inside a single `MERGE`
+
+You can no longer read a property of one pattern element while still defining another in the same `MERGE`.
+
+```cypher
+// Cypher 5 (still works there)
+MERGE (a {foo:1})-[:T]->(b {foo:a.foo})
+
+// Cypher 25 — split it
+MERGE (a {foo:1})
+MERGE (a)-[:T]->(b {foo:a.foo})
+```
+
+### Composite-database graph references
+
+A qualified composite graph name must be one backticked token.
+
+```cypher
+// Cypher 5
+USE composite.`sub1`
+
+// Cypher 25
+USE `composite.sub1`
+```
+
+### Unicode in unescaped identifiers
+
+Control / special-category codepoints (`\u0085`, `\u0024`, and others) are no longer accepted inside bare identifiers. Either rename the identifier or wrap it in backticks.
+
+## Removed database / index options
+
+- `CREATE INDEX … OPTIONS { indexProvider: '…' }` — drop the option; the planner picks the provider.
+- `CREATE CONSTRAINT … OPTIONS { indexProvider: '…' }` — same.
+- `CREATE DATABASE … OPTIONS { seedCredentials: … }` — removed.
+- `CREATE DATABASE … OPTIONS { existingDataSeedInstance: … }` — replaced by `existingDataSeedServer`.
+
+## Removed procedures
+
+Replace calls before switching to Cypher 25:
+
+| Removed                                   | Replacement                                                         |
+|-------------------------------------------|---------------------------------------------------------------------|
+| `db.create.setVectorProperty(n, p, arr)`  | `SET n[p] = vector($arr, $dim, FLOAT32)`                            |
+| `db.index.vector.createNodeIndex(...)`    | `CREATE VECTOR INDEX name FOR (n:Label) ON (n.prop) OPTIONS {...}`  |
+| `dbms.cluster.readReplicaToggle(...)`     | Modern cluster admin via `neo4j-admin` / Aura API                   |
+| `dbms.cluster.uncordonServer(...)`        | `neo4j-admin server uncordon`                                       |
+| `dbms.quarantineDatabase(...)`            | No direct replacement; use database lifecycle commands              |
+| `dbms.upgrade()`                          | Handled automatically by the server on startup                      |
+| `dbms.upgradeStatus()`                    | `SHOW DATABASES` plus server logs                                   |
+
+## Behavior tightening
+
+- **Impossible `REVOKE` statements now raise an error** (were silent notifications in Cypher 5). Audit any generated permission scripts.
+
+## Things deprecated but not yet removed
+
+- `CREATE DATABASE … OPTIONS { existingData: … }` — plan to move to `existingDataSeedServer`.
+
+## Quick regex checklist for audits
+
+```
+SET\s+[A-Za-z_][\w]*\s*=\s*[A-Za-z_][\w]*\s*(?:[\s,;)\]]|$)   # SET a = b
+MERGE\s*\([^)]*\{[^}]*\b\w+\.\w+\b                             # MERGE with x.y inside properties
+OPTIONS\s*\{[^}]*indexProvider                                 # deprecated option
+db\.create\.setVectorProperty                                  # removed procs
+db\.index\.vector\.createNodeIndex
+dbms\.(upgrade|upgradeStatus|quarantineDatabase|cluster\.readReplicaToggle|cluster\.uncordonServer)
+```
+
+The regexes are conservative; review each hit — a pattern like `SET a = b` is only a problem when `b` is a node or relationship variable.

--- a/neo4j-cypher-25-skill/references/new-features.md
+++ b/neo4j-cypher-25-skill/references/new-features.md
@@ -1,0 +1,137 @@
+# Cypher 25 new features (vs Cypher 5)
+
+Everything here is **additive** over Cypher 5 and only available under `CYPHER 25`.
+
+## Vector type and functions
+
+First-class vector value type:
+
+```cypher
+CREATE (m:Movie {title: "Matrix",
+                 embedding: vector([0.1, 0.2, 0.3], 3, FLOAT32)})
+```
+
+Functions: `vector()`, `vector_distance(a, b, 'cosine'|'euclidean')`, `vector_norm(v)`, `vector_dimension_count(v)`.
+
+Vector indexes now support **multiple labels / rel-types and filter properties**:
+
+```cypher
+CREATE VECTOR INDEX movie_emb FOR (m:Movie|Show) ON (m.embedding)
+OPTIONS { indexConfig: {
+  `vector.dimensions`: 1536,
+  `vector.similarity_function`: 'cosine'
+}};
+```
+
+Vector-similarity search in `MATCH`:
+
+```cypher
+MATCH (m:Movie) SEARCH m.embedding NEAREST $query_vec LIMIT 10
+RETURN m.title;
+```
+
+## Dynamic labels and relationship types
+
+Native, no APOC needed:
+
+```cypher
+WITH 'Person' AS lbl, 'KNOWS' AS rel
+MATCH (a:$(lbl) {name: 'Alice'})-[:$(rel)]->(b)
+RETURN b;
+```
+
+Works in `MATCH`, `MERGE`, `CREATE`, `SET`, `REMOVE`.
+
+## Conditional subqueries
+
+```cypher
+MATCH (p:Person {id: $id})
+CALL {
+  WITH p
+  WHEN p.age >= 18 THEN
+    CREATE (p)-[:IS]->(:Adult)
+  ELSE
+    CREATE (p)-[:IS]->(:Minor)
+}
+RETURN p;
+```
+
+## Collection functions (namespaced)
+
+| Function           | Purpose                          |
+|--------------------|----------------------------------|
+| `coll.sort(list)`  | sorted copy                      |
+| `coll.distinct(list)` | dedupe preserving order       |
+| `coll.flatten(list)`  | one-level flatten             |
+| `coll.max(list)` / `coll.min(list)` | extremes        |
+| `coll.indexOf(list, x)` | first index of `x`          |
+| `coll.insert(list, idx, x)` | insert at idx           |
+| `coll.remove(list, idx)` | remove at idx              |
+
+## GQL-style composition
+
+```cypher
+LET doubled = [x IN $nums | x * 2]
+FILTER doubled > 10
+NEXT
+RETURN doubled;
+```
+
+- `LET` binds a value to a variable (like `WITH … AS …` but single-binding).
+- `FILTER` is a standalone filtering clause.
+- `NEXT` chains a subsequent statement without `WITH`.
+- `RETURN ALL` / `WITH ALL` — explicit non-deduped projection.
+
+## Walk semantics in `MATCH`
+
+```cypher
+MATCH REPEATABLE ELEMENTS p = (a)-[*..5]-(b)
+WHERE a.name = 'Alice' AND b.name = 'Bob'
+RETURN p;
+```
+
+`REPEATABLE ELEMENTS` allows the same relationship to appear more than once in a path (walk semantics). `DIFFERENT RELATIONSHIPS` (the default) matches Cypher 5 behavior.
+
+## Temporal formatting
+
+```cypher
+RETURN format(datetime(), 'yyyy-MM-dd HH:mm:ss zzz') AS stamp;
+```
+
+Temporal constructors accept an optional pattern argument for parsing.
+
+## Miscellaneous additions
+
+- **Read→write without `WITH`**: `MATCH (p:Person) CREATE (p)-[:OWNS]->(:Pet {name:'Rex'})` is legal.
+- **Parameters starting with a digit**: `$0user`, `$42`.
+- **Parameters in `SHORTEST k`/`ANY` path selectors**: `MATCH p = SHORTEST $k (a)-[*]-(b)`.
+- **`replace(str, from, to, limit)`** — optional `limit` argument.
+- **`PROPERTY_EXISTS(element, 'name')`** — direct property existence check.
+- **Hyperbolic trig**: `sinh`, `cosh`, `tanh`, `coth`.
+- **GQL naming aliases** (same semantics, SQL/GQL-style names): `ceiling`, `ln`, `local_time`, `local_datetime`, `zoned_time`, `zoned_datetime`, `duration_between`, `path_length`, `collect_list`, `percentile_cont`, `percentile_disc`, `stdev_samp`, `stdev_pop`.
+- **`allReduce(path, accumulator, expr)`** — stepwise path evaluation for planning/routing problems.
+- **`SHOW TRANSACTIONS`** now exposes `currentQueryProgress`.
+- **`SHOW CONSTRAINTS`** gains `enforcedLabel` and `classification` columns.
+- **Imported variables are constants** inside `COLLECT { … }`, `COUNT { … }`, `EXISTS { … }` subqueries — no more surprise re-binding.
+
+## New constraint kinds
+
+```cypher
+CREATE CONSTRAINT person_label_exists
+FOR (n:Person) REQUIRE n:Person IS NODE LABEL EXISTENCE;
+
+CREATE CONSTRAINT knows_source
+FOR ()-[r:KNOWS]-() REQUIRE (r) IS RELATIONSHIP SOURCE LABEL Person;
+
+CREATE CONSTRAINT knows_target
+FOR ()-[r:KNOWS]-() REQUIRE (r) IS RELATIONSHIP TARGET LABEL Person;
+```
+
+## Graph type system (preview)
+
+```cypher
+SHOW CURRENT GRAPH TYPE;
+ALTER CURRENT GRAPH TYPE ADD NODE (:Person {name: STRING});
+```
+
+Preview feature — the syntax may still evolve inside Cypher 25's additive window.


### PR DESCRIPTION
Covers the Cypher language split introduced in Neo4j 2025.06: the CYPHER 25 / CYPHER 5 version selector, per-database default language, breaking changes that will fail existing Cypher 5 queries, and the headline Cypher 25 additions (vector type, dynamic labels via $(expr), conditional subqueries, coll.* functions, walk semantics).