### PR TITLE
Fix neo4j-cypher-skill: -- comments to // and correct GQL clause status

### DIFF
--- a/neo4j-cypher-skill/README.md
+++ b/neo4j-cypher-skill/README.md
@@ -43,7 +43,7 @@ Loaded on demand — not bundled into the main skill context:
 
 - Driver migration or version upgrade → `neo4j-migration-skill`
 - Database administration (users, config, backups) → `neo4j-cli-tools-skill`
-- GQL clauses: `LET`, `FINISH`, `FILTER`, `INSERT` are parse errors in Cypher 25
+- GQL clauses: `LET`, `FINISH`, `FILTER`, and `INSERT` are valid in Cypher 25 (introduced via GQL conformance, mostly in Neo4j 2025.06); not available on older versions
 
 ## Related skills
 

--- a/neo4j-cypher-skill/SKILL.md
+++ b/neo4j-cypher-skill/SKILL.md
@@ -17,7 +17,8 @@ compatibility: Neo4j >= 2025.01 (safe baseline); Cypher 25
 ## When NOT to Use
 - **Driver migration/API changes** → `neo4j-migration-skill`
 - **DB admin** (users, config, backups) → `neo4j-cli-tools-skill`
-- **GQL clauses** (`LET`, `FINISH`, `FILTER`, `INSERT`) — illegal in Cypher; use `WITH`/`RETURN`/`WHERE`/`CREATE`
+
+GQL conformance note: `LET`, `FINISH`, `FILTER`, and `INSERT` are valid Cypher 25 clauses (introduced via GQL conformance, mostly in Neo4j 2025.06). On older versions, fall back to `WITH` / (omit RETURN) / `WHERE` / `CREATE`. `INSERT` requires `&`-separated multi-labels and does not support dynamic labels/types.
 
 ---
 
@@ -243,10 +244,10 @@ Full trap table → [references/syntax-traps.md](references/syntax-traps.md)
 
 Default: parameterized queries. **Return named properties, not full nodes or `RETURN *`.**
 ```cypher
--- RIGHT: agent gets named fields it can reason over
+// RIGHT: agent gets named fields it can reason over
 CYPHER 25 MATCH (n:Organization {name: $name}) RETURN n.name, n.founded, n.industry LIMIT 10
 
--- WRONG: full node object wastes tokens, leaks all properties, agent can't extract fields cleanly
+// WRONG: full node object wastes tokens, leaks all properties, agent can't extract fields cleanly
 CYPHER 25 MATCH (n:Organization {name: $name}) RETURN n LIMIT 10
 ```
 Exception: schema/diagnostic queries (`CALL db.schema.visualization()`, `SHOW INDEXES YIELD *`, `EXPLAIN`) where the object is the point.

--- a/neo4j-cypher-skill/references/apoc.md
+++ b/neo4j-cypher-skill/references/apoc.md
@@ -185,10 +185,10 @@ Triggers fire Cypher on write events. Require `apoc.trigger.enabled=true` in `ap
 // Install — run from system database
 USE system
 CALL apoc.trigger.install(
-  'neo4j',                                      -- target database
-  'stamp-created',                              -- trigger name
+  'neo4j',                                      // target database
+  'stamp-created',                              // trigger name
   'UNWIND $createdNodes AS n SET n.createdAt = datetime()',
-  {phase: 'before'}                             -- before | after | rollback | afterAsync
+  {phase: 'before'}                             // before | after | rollback | afterAsync
 ) YIELD name, installed RETURN name, installed
 
 // List triggers for current database
@@ -235,13 +235,13 @@ Both deprecated in Cypher 25 — prefer native `CASE` + conditional `CALL { ... 
 
 ```cypher
 // Flatten nested list
-RETURN apoc.coll.flatten([[1,2],[3,[4,5]]], true)  -- [1,2,3,4,5]
+RETURN apoc.coll.flatten([[1,2],[3,[4,5]]], true)  // [1,2,3,4,5]
 
 // Distinct union of two lists
-RETURN apoc.coll.union([1,2,3], [2,3,4])           -- [1,2,3,4]
+RETURN apoc.coll.union([1,2,3], [2,3,4])           // [1,2,3,4]
 
 // Deduplicate list
-RETURN apoc.coll.toSet([1,2,2,3])                  -- [1,2,3]
+RETURN apoc.coll.toSet([1,2,2,3])                  // [1,2,3]
 ```
 
 `flatten` and `toSet` deprecated in Cypher 25 — use `apoc.coll.flatten` only for deeply nested lists where the native `[x IN list | ...]` flattening is insufficient.
@@ -252,13 +252,13 @@ RETURN apoc.coll.toSet([1,2,2,3])                  -- [1,2,3]
 
 ```cypher
 // Merge two maps (right overwrites left on key collision)
-RETURN apoc.map.merge({a:1, b:2}, {b:3, c:4})      -- {a:1, b:3, c:4}
+RETURN apoc.map.merge({a:1, b:2}, {b:3, c:4})      // {a:1, b:3, c:4}
 
 // Build map from list of [key, value] pairs
-RETURN apoc.map.fromPairs([['k1',1],['k2',2]])      -- {k1:1, k2:2}
+RETURN apoc.map.fromPairs([['k1',1],['k2',2]])      // {k1:1, k2:2}
 
 // Extract sub-map by keys
-RETURN apoc.map.submap({a:1,b:2,c:3}, ['a','c'])    -- {a:1, c:3}
+RETURN apoc.map.submap({a:1,b:2,c:3}, ['a','c'])    // {a:1, c:3}
 ```
 
 ---
@@ -272,7 +272,7 @@ RETURN apoc.convert.toJson(n{.*})
 
 // Parse JSON string → Cypher list
 WITH '[{"name":"Alice"},{"name":"Bob"}]' AS raw
-RETURN apoc.convert.fromJsonList(raw, '$[*].name', [])  -- ['Alice','Bob']
+RETURN apoc.convert.fromJsonList(raw, '$[*].name', [])  // ['Alice','Bob']
 
 // Parse JSON string → Cypher map
 WITH '{"score":0.9,"tier":"A"}' AS raw
@@ -302,17 +302,17 @@ RETURN apoc.date.convert(1710489600000, 'ms', 's')
 
 ```cypher
 // Split by regex
-RETURN apoc.text.split('a,b,,c', ',', 0)           -- ['a','b','','c']
+RETURN apoc.text.split('a,b,,c', ',', 0)           // ['a','b','','c']
 
 // Join list of strings
-RETURN apoc.text.join(['foo','bar','baz'], '-')     -- 'foo-bar-baz'
+RETURN apoc.text.join(['foo','bar','baz'], '-')     // 'foo-bar-baz'
 
 // URL-safe slug
-RETURN apoc.text.slug('Hello World! 2025', '-')    -- 'hello-world-2025'
+RETURN apoc.text.slug('Hello World! 2025', '-')    // 'hello-world-2025'
 
 // Regex capture groups
 RETURN apoc.text.regexGroups('2025-04-01', '(\\d{4})-(\\d{2})-(\\d{2})')
--- [['2025-04-01','2025','04','01']]
+// [['2025-04-01','2025','04','01']]
 ```
 
 ---

--- a/neo4j-cypher-skill/references/indexes.md
+++ b/neo4j-cypher-skill/references/indexes.md
@@ -7,15 +7,15 @@ Every `MATCH`, `MERGE`, or `WHERE` predicate on a node/relationship property req
 **Index requires a label.** Index lookup only happens when the node has a label in the pattern. Without a label, Neo4j cannot identify which index to use and falls back to a full scan even if an index exists.
 
 ```cypher
--- IGNORED: no label → no index used, full scan
+// IGNORED: no label → no index used, full scan
 MATCH (n {email: $email}) RETURN n.name, n.email
 
--- USED: label present → RANGE/UNIQUE index on Person.email
+// USED: label present → RANGE/UNIQUE index on Person.email
 MATCH (n:Person {email: $email}) RETURN n.name, n.email
 
--- IGNORED in MERGE too: label required
-MERGE (n {email: $email})          -- full scan, no lock
-MERGE (n:Person {email: $email})   -- index lookup + constraint lock
+// IGNORED in MERGE too: label required
+MERGE (n {email: $email})          // full scan, no lock
+MERGE (n:Person {email: $email})   // index lookup + constraint lock
 ```
 
 MERGE compounds this: `MERGE (n:Person {email: $email})` = `MATCH` + `CREATE IF NOT EXISTS`. The MATCH phase scans without an index. With a constraint, the MERGE also acquires a lock on the constraint entry, preventing concurrent duplicate creation (atomicity guarantee).
@@ -70,28 +70,28 @@ Consequences:
 ## Create syntax
 
 ```cypher
--- RANGE (numbers, dates, booleans, strings: =, >, <, STARTS WITH, IS NOT NULL)
+// RANGE (numbers, dates, booleans, strings: =, >, <, STARTS WITH, IS NOT NULL)
 CREATE RANGE INDEX person_email IF NOT EXISTS FOR (n:Person) ON (n.email)
 
--- RANGE on relationship
+// RANGE on relationship
 CREATE RANGE INDEX event_date IF NOT EXISTS FOR ()-[r:OCCURRED_ON]-() ON (r.date)
 
--- RANGE composite (all listed props must appear in WHERE for planner to use it)
+// RANGE composite (all listed props must appear in WHERE for planner to use it)
 CREATE INDEX person_name_age IF NOT EXISTS FOR (n:Person) ON (n.name, n.age)
 
--- RANGE composite on relationship
+// RANGE composite on relationship
 CREATE INDEX purchased_date_amount IF NOT EXISTS FOR ()-[r:PURCHASED]-() ON (r.date, r.amount)
 
--- TEXT (string CONTAINS, ENDS WITH, IN list — trigram internally)
+// TEXT (string CONTAINS, ENDS WITH, IN list — trigram internally)
 CREATE TEXT INDEX person_name_text IF NOT EXISTS FOR (n:Person) ON (n.name)
 
--- TEXT on relationship
+// TEXT on relationship
 CREATE TEXT INDEX rates_interest IF NOT EXISTS FOR ()-[r:KNOWS]-() ON (r.interest)
 
--- POINT (spatial)
+// POINT (spatial)
 CREATE POINT INDEX place_location IF NOT EXISTS FOR (n:Place) ON (n.location)
 
--- POINT with spatial bounding box config (WGS-84 geographic CRS)
+// POINT with spatial bounding box config (WGS-84 geographic CRS)
 CREATE POINT INDEX place_wgs IF NOT EXISTS FOR (n:Place) ON (n.location)
 OPTIONS {
   indexConfig: {
@@ -99,13 +99,13 @@ OPTIONS {
     `spatial.wgs-84.max`: [180.0, 90.0]
   }
 }
--- Other spatial CRS config keys: spatial.cartesian.min/max, spatial.cartesian-3d.min/max, spatial.wgs-84-3d.min/max
+// Other spatial CRS config keys: spatial.cartesian.min/max, spatial.cartesian-3d.min/max, spatial.wgs-84-3d.min/max
 
--- FULLTEXT (Lucene; multi-label, multi-prop, scored)
+// FULLTEXT (Lucene; multi-label, multi-prop, scored)
 CREATE FULLTEXT INDEX search_articles IF NOT EXISTS
   FOR (n:Article|BlogPost) ON EACH [n.title, n.body]
 
--- FULLTEXT with analyzer + eventually-consistent background updates
+// FULLTEXT with analyzer + eventually-consistent background updates
 CREATE FULLTEXT INDEX search_articles IF NOT EXISTS
   FOR (n:Article|BlogPost) ON EACH [n.title, n.body]
 OPTIONS {
@@ -115,7 +115,7 @@ OPTIONS {
   }
 }
 
--- LOOKUP (auto-created per database — shown for reference only; do NOT drop or recreate)
+// LOOKUP (auto-created per database — shown for reference only; do NOT drop or recreate)
 CREATE LOOKUP INDEX node_label_lookup FOR (n) ON EACH labels(n)
 CREATE LOOKUP INDEX rel_type_lookup  FOR ()-[r]-() ON EACH type(r)
 ```
@@ -140,39 +140,39 @@ Constraints enforce data integrity AND create an implicit **RANGE index** (UNIQU
 **Edition notes**: UNIQUE and NOT NULL (existence) available in all editions. NODE KEY, RELATIONSHIP KEY, RELATIONSHIP UNIQUE, property type (`IS ::`) require **Enterprise Edition**.
 
 ```cypher
--- UNIQUE node — creates implicit RANGE index; MERGE acquires lock
+// UNIQUE node — creates implicit RANGE index; MERGE acquires lock
 CREATE CONSTRAINT person_email_unique IF NOT EXISTS
   FOR (n:Person) REQUIRE n.email IS UNIQUE
 
--- UNIQUE composite node
+// UNIQUE composite node
 CREATE CONSTRAINT book_title_year IF NOT EXISTS
   FOR (n:Book) REQUIRE (n.title, n.publicationYear) IS UNIQUE
 
--- UNIQUE relationship (Enterprise)
+// UNIQUE relationship (Enterprise)
 CREATE CONSTRAINT sequel_order IF NOT EXISTS
   FOR ()-[r:SEQUEL_OF]-() REQUIRE r.order IS UNIQUE
 
--- NODE KEY — composite uniqueness + existence; creates composite RANGE index (Enterprise)
+// NODE KEY — composite uniqueness + existence; creates composite RANGE index (Enterprise)
 CREATE CONSTRAINT person_key IF NOT EXISTS
   FOR (n:Person) REQUIRE (n.firstName, n.lastName) IS NODE KEY
 
--- RELATIONSHIP KEY (Enterprise)
+// RELATIONSHIP KEY (Enterprise)
 CREATE CONSTRAINT owns_key IF NOT EXISTS
   FOR ()-[r:OWNS]-() REQUIRE r.ownershipId IS RELATIONSHIP KEY
 
--- NOT NULL node (existence only — no index created)
+// NOT NULL node (existence only — no index created)
 CREATE CONSTRAINT person_name_exists IF NOT EXISTS
   FOR (n:Person) REQUIRE n.name IS NOT NULL
 
--- NOT NULL relationship
+// NOT NULL relationship
 CREATE CONSTRAINT wrote_year_exists IF NOT EXISTS
   FOR ()-[r:WROTE]-() REQUIRE r.year IS NOT NULL
 
--- PROPERTY TYPE node (Enterprise) — IS ::, IS TYPED, and :: are synonyms; IS :: is preferred
+// PROPERTY TYPE node (Enterprise) — IS ::, IS TYPED, and :: are synonyms; IS :: is preferred
 CREATE CONSTRAINT movie_title_type IF NOT EXISTS
   FOR (n:Movie) REQUIRE n.title IS :: STRING
 
--- PROPERTY TYPE relationship (Enterprise)
+// PROPERTY TYPE relationship (Enterprise)
 CREATE CONSTRAINT rating_type IF NOT EXISTS
   FOR ()-[r:RATED]-() REQUIRE r.rating IS :: INTEGER
 ```
@@ -186,13 +186,13 @@ Supported types for `IS ::`: `BOOLEAN`, `STRING`, `INTEGER`, `FLOAT`, `DATE`, `L
 `MERGE` = `MATCH` + conditional `CREATE`. Without an index/constraint on the merge property, the MATCH phase scans all nodes of that label.
 
 ```cypher
--- Without constraint: full scan + no atomicity guarantee
+// Without constraint: full scan + no atomicity guarantee
 MERGE (p:Person {email: $email})
 
--- With UNIQUE constraint:
---   1. O(log n) lookup via implicit RANGE index
---   2. Lock on constraint entry → prevents concurrent duplicate creation
---   3. Atomic: two concurrent MERGEs cannot both create the same node
+// With UNIQUE constraint:
+//   1. O(log n) lookup via implicit RANGE index
+//   2. Lock on constraint entry → prevents concurrent duplicate creation
+//   3. Atomic: two concurrent MERGEs cannot both create the same node
 CREATE CONSTRAINT person_email_unique IF NOT EXISTS
   FOR (n:Person) REQUIRE n.email IS UNIQUE
 
@@ -211,31 +211,31 @@ Use `MERGE (n:Label {keyProp: $val}) SET n.otherProp = $other` — merge only on
 Fulltext indexes use Lucene — tokenized, scored, not a filter index. Result nodes must be joined back to the graph. Supports `LIST<STRING>` properties — each element analyzed independently.
 
 ```cypher
--- Create (multi-label, multi-prop)
+// Create (multi-label, multi-prop)
 CREATE FULLTEXT INDEX article_search IF NOT EXISTS
   FOR (n:Article|BlogPost) ON EACH [n.title, n.body]
 
--- Query nodes — returns node + score (descending)
+// Query nodes — returns node + score (descending)
 CALL db.index.fulltext.queryNodes('article_search', 'graph database')
 YIELD node, score
 WHERE score > 0.5
 RETURN node.title, score
 ORDER BY score DESC LIMIT 10
 
--- Query relationships
+// Query relationships
 CALL db.index.fulltext.queryRelationships('rel_search', 'query string')
 YIELD relationship, score
 RETURN relationship, score
 
--- Lucene query syntax:
---   'graph database'         token AND (default)
---   '"graph database"'       exact phrase
---   'graph OR database'      OR
---   'graph -relational'      NOT
---   'graph~'                 fuzzy
---   'graph*'                 wildcard prefix
---   'title:graph'            field-scoped search
---   'team:"Operations"'      field + exact phrase
+// Lucene query syntax:
+//   'graph database'         token AND (default)
+//   '"graph database"'       exact phrase
+//   'graph OR database'      OR
+//   'graph -relational'      NOT
+//   'graph~'                 fuzzy
+//   'graph*'                 wildcard prefix
+//   'title:graph'            field-scoped search
+//   'team:"Operations"'      field + exact phrase
 ```
 
 Fulltext index does NOT participate in normal WHERE predicate planning. Use `CALL db.index.fulltext.queryNodes` / `queryRelationships` explicitly.
@@ -247,37 +247,37 @@ Fulltext index does NOT participate in normal WHERE predicate planning. Use `CAL
 Force the planner to use a specific index (or specific type) when it chooses a suboptimal plan. Use `EXPLAIN` first to confirm the issue.
 
 ```cypher
--- Generic hint — planner uses any available index on the property
+// Generic hint — planner uses any available index on the property
 MATCH (p:Person)
 USING INDEX p:Person(email)
 WHERE p.email = $email
 RETURN p.name, p.email
 
--- Force RANGE index specifically
+// Force RANGE index specifically
 MATCH (s:Scientist {born: 1850})
 USING RANGE INDEX s:Scientist(born)
 RETURN s.name, s.born
 
--- Force TEXT index specifically
+// Force TEXT index specifically
 MATCH (c:Country)
 USING TEXT INDEX c:Country(name)
 WHERE c.name = 'Country7'
 RETURN c.name, c.population
 
--- Two hints in one query — forces both path ends to use their index (enables index join)
+// Two hints in one query — forces both path ends to use their index (enables index join)
 MATCH (p:Person)-[:ACTED_IN]->(m:Movie)<-[:DIRECTED]-(p2:Person)
 USING INDEX p:Person(name)
 USING INDEX p2:Person(name)
 WHERE p.name CONTAINS 'John' AND p2.name CONTAINS 'George'
 RETURN p.name, p2.name, m.title
 
--- Relationship index hint
+// Relationship index hint
 MATCH (u:User)-[r:RATED]->(m:Movie)
 USING INDEX r:RATED(rating)
 WHERE r.rating = 5
 RETURN u.name, r.rating, m.title
 
--- Relationship TEXT index hint
+// Relationship TEXT index hint
 MATCH (n:Inventor)-[i:INVENTED_BY]->(inv:Invention)
 USING TEXT INDEX i:INVENTED_BY(location)
 WHERE i.location = 'Location7'
@@ -296,36 +296,36 @@ Rules:
 ## Inspect indexes and constraints
 
 ```cypher
--- All indexes — core fields
+// All indexes — core fields
 SHOW INDEXES YIELD name, type, state, labelsOrTypes, properties, populationPercent
-  WHERE state <> 'ONLINE' OR populationPercent < 100   -- building or not ready
+  WHERE state <> 'ONLINE' OR populationPercent < 100   // building or not ready
 
--- Full details (includes: indexSize, lastRead, readCount, lastWrite, writeCount, indexConfig)
+// Full details (includes: indexSize, lastRead, readCount, lastWrite, writeCount, indexConfig)
 SHOW INDEXES YIELD *
 
--- Filter by type
+// Filter by type
 SHOW RANGE INDEXES    YIELD name, state, labelsOrTypes, properties
 SHOW TEXT INDEXES     YIELD name, state, labelsOrTypes, properties
 SHOW FULLTEXT INDEXES YIELD name, state, indexConfig
 SHOW VECTOR INDEXES   YIELD name, state, populationPercent, indexConfig
 SHOW LOOKUP INDEXES   YIELD name, state
 
--- Unused index candidates (never read — review for removal)
+// Unused index candidates (never read — review for removal)
 SHOW INDEXES YIELD name, type, readCount, lastRead
   WHERE readCount = 0 AND type <> 'LOOKUP'
   RETURN name, type, lastRead
   ORDER BY lastRead
 
--- Constraints
+// Constraints
 SHOW CONSTRAINTS YIELD name, type, labelsOrTypes, properties
 
--- Check index used in query plan
+// Check index used in query plan
 EXPLAIN MATCH (p:Person {email: $email}) RETURN p
--- 'NodeIndexSeek' or 'NodeUniqueIndexSeek' — index used ✓
--- 'NodeIndexContainsScan' — TEXT index via CONTAINS ✓
--- 'NodeByLabelScan' or 'AllNodesScan' — no index, add one
+// 'NodeIndexSeek' or 'NodeUniqueIndexSeek' — index used ✓
+// 'NodeIndexContainsScan' — TEXT index via CONTAINS ✓
+// 'NodeByLabelScan' or 'AllNodesScan' — no index, add one
 
--- PROFILE for timing (run twice; second run = true cost)
+// PROFILE for timing (run twice; second run = true cost)
 PROFILE MATCH (p:Person) WHERE p.name CONTAINS 'Robert' RETURN p.name
 ```
 
@@ -336,15 +336,15 @@ PROFILE MATCH (p:Person) WHERE p.name CONTAINS 'Robert' RETURN p.name
 Create constraints and indexes **before** bulk import. MERGE during load uses the index for every row.
 
 ```cypher
--- 1. Uniqueness constraints first (implicit RANGE index)
+// 1. Uniqueness constraints first (implicit RANGE index)
 CREATE CONSTRAINT person_id    IF NOT EXISTS FOR (n:Person)  REQUIRE n.id    IS UNIQUE;
 CREATE CONSTRAINT movie_id     IF NOT EXISTS FOR (n:Movie)   REQUIRE n.id    IS UNIQUE;
 CREATE CONSTRAINT org_name     IF NOT EXISTS FOR (n:Org)     REQUIRE n.name  IS UNIQUE;
 
--- 2. Additional lookup indexes (non-unique properties used in MATCH/WHERE)
+// 2. Additional lookup indexes (non-unique properties used in MATCH/WHERE)
 CREATE RANGE INDEX person_email IF NOT EXISTS FOR (n:Person) ON (n.email);
 CREATE TEXT  INDEX movie_title  IF NOT EXISTS FOR (n:Movie)  ON (n.title);
 
--- 3. Wait for all to be ONLINE before loading
+// 3. Wait for all to be ONLINE before loading
 SHOW INDEXES YIELD name, state WHERE state <> 'ONLINE' RETURN name, state;
 ```

--- a/neo4j-cypher-skill/references/syntax-traps.md
+++ b/neo4j-cypher-skill/references/syntax-traps.md
@@ -14,9 +14,9 @@ Load this when debugging a syntax error or validating a query before returning i
 | `FOREACH ... RETURN` | Use `UNWIND` when you need RETURN |
 | `least(a,b)` / `greatest(a,b)` | `CASE WHEN a < b THEN a ELSE b END` |
 | `-- SQL comment` | `// Cypher comment` |
-| `FILTER x IN list WHERE ...` | `[x IN list WHERE ...]` — FILTER is GQL, illegal in Cypher |
-| `LET x = expr` | `WITH expr AS x` — LET is GQL, illegal |
-| `INSERT (p:Person {name:'A'})` | `CREATE (p:Person {name: 'A'})` — INSERT is GQL, illegal |
+| `FILTER x IN list WHERE ...` | `[x IN list WHERE ...]` — `FILTER` clause exists (Cypher 25 / 2025.06) but is not a list-comprehension form |
+| `LET x = expr` | `LET` clause valid in Cypher 25 (Neo4j 2025.06+); on older versions use `WITH expr AS x` |
+| `INSERT (p:Person {name:'A'})` | `INSERT` is a Cypher 25 synonym for `CREATE` (Neo4j 2025.06+) but multi-labels must use `&` not `:` and dynamic labels/types are not supported; on older versions use `CREATE (p:Person {name: 'A'})` |
 | `shortestPath((a)-[*]->(b))` | `SHORTEST 1 (a)(()-[]->()){1,}(b)` |
 | `allShortestPaths((a)-[*]->(b))` | `ALL SHORTEST (a)(()-[]->()){1,}(b)` |
 | `id(n)` | `elementId(n)` |


### PR DESCRIPTION
- Replace SQL -- comments with Cypher // across SKILL.md, indexes.md, apoc.md
- Correct GQL claim: LET, FINISH, FILTER, INSERT are valid Cypher 25 clauses (introduced via GQL conformance, mostly Neo4j 2025.06), not parse errors
- Update README.md, SKILL.md, and syntax-traps.md to reflect actual support