### PR TITLE
[codex] Add hybrid search guidance to vector skill

### DIFF
--- a/neo4j-cypher-skill/SKILL.md
+++ b/neo4j-cypher-skill/SKILL.md
@@ -17,6 +17,7 @@ compatibility: Neo4j >= 2025.01 (safe baseline); Cypher 25
 ## When NOT to Use
 - **Driver migration/API changes** → `neo4j-migration-skill`
 - **DB admin** (users, config, backups) → `neo4j-cli-tools-skill`
+- **Hybrid search that combines vector with fulltext or other ranked sources** → `neo4j-vector-index-skill`
 
 GQL conformance note: `LET`, `FINISH`, `FILTER`, and `INSERT` are valid Cypher 25 clauses (introduced via GQL conformance, mostly in Neo4j 2025.06). On older versions, fall back to `WITH` / (omit RETURN) / `WHERE` / `CREATE`. `INSERT` requires `&`-separated multi-labels and does not support dynamic labels/types.
 

--- a/neo4j-gds-skill/README.md
+++ b/neo4j-gds-skill/README.md
@@ -8,6 +8,7 @@ Agent skill for Neo4j Graph Data Science (GDS) — running graph algorithms on s
 - Execution modes: stream / stats / mutate / write and when to use each
 - Core algorithms: PageRank, Louvain, WCC, Betweenness Centrality, Node Similarity, FastRP, KNN
 - FastRP → KNN recommendation pipeline pattern
+- Writing node embeddings for Neo4j vector indexes / structural similarity search
 - Memory estimation before large projections and algorithm runs
 - GDS Python client (`graphdatascience`) — connection, projection, algorithm calls
 - Graph catalog operations: project, list, drop, subgraph filter
@@ -24,6 +25,7 @@ Agent skill for Neo4j Graph Data Science (GDS) — running graph algorithms on s
 - **Aura Graph Analytics** (BC/VDC/serverless) → `neo4j-aura-graph-analytics-skill`
 - **Cypher query authoring** → `neo4j-cypher-skill`
 - **Driver/connection setup** → `neo4j-driver-python-skill`
+- **Creating/querying vector indexes over written embeddings** → `neo4j-vector-index-skill`
 
 ## Install
 

--- a/neo4j-gds-skill/SKILL.md
+++ b/neo4j-gds-skill/SKILL.md
@@ -5,7 +5,8 @@ description: Neo4j Graph Data Science (GDS) plugin — graph projection, algorit
   (graphdatascience v1.21). Use when running gds.pageRank, gds.louvain, gds.wcc, gds.fastRP,
   gds.knn, gds.betweenness, gds.nodeSimilarity, or any gds.* procedure; projecting named
   in-memory graphs with gds.graph.project or graph.project; chaining algorithms with mutate
-  mode; computing node embeddings for ML; building recommendation systems with FastRP + KNN.
+  mode; computing node embeddings for ML, structural similarity, or vector search; building
+  recommendation systems with FastRP + KNN.
   Also triggers on GraphDataScience, GdsSessions, graph catalog operations, ML pipelines,
   node classification, link prediction.
   Does NOT cover Aura Graph Analytics serverless sessions — use neo4j-aura-graph-analytics-skill.
@@ -19,6 +20,7 @@ allowed-tools: Bash WebFetch
 - Running GDS algorithms on self-managed Neo4j or Aura Pro (embedded plugin)
 - Projecting named in-memory graphs, running centrality/community/similarity/path/embedding algorithms
 - Chaining algorithms via `mutate` mode; building FastRP → KNN pipelines
+- Writing node embeddings for Neo4j vector indexes / structural similarity search
 - Memory estimation before large graph operations
 - GDS Python client (`graphdatascience`) workflows
 
@@ -27,6 +29,7 @@ allowed-tools: Bash WebFetch
 - **Cypher query authoring** → `neo4j-cypher-skill`
 - **Driver/connection setup** → `neo4j-driver-python-skill`
 - **GraphRAG retrieval** → `neo4j-graphrag-skill`
+- **Creating/querying vector indexes over written embeddings** → `neo4j-vector-index-skill`
 
 | Deployment | Use |
 |---|---|
@@ -306,6 +309,8 @@ gds.fastRP.mutate(G, embeddingDimension=256, iterationWeights=[0.0, 1.0, 1.0],
                   randomSeed=42, mutateProperty="embedding")
 gds.fastRP.write(G, embeddingDimension=256, writeProperty="embedding", randomSeed=42)
 ```
+
+For ANN search over structural embeddings, after `write`, create a Neo4j vector index over the written property. Use `neo4j-vector-index-skill`.
 
 ### KNN — K-Nearest Neighbors
 

--- a/neo4j-gds-skill/references/algorithms.md
+++ b/neo4j-gds-skill/references/algorithms.md
@@ -100,7 +100,7 @@ RETURN totalCost, [nodeId IN nodeIds | gds.util.asNode(nodeId).name] AS nodes
 
 | Algorithm | Procedure | Tier | Inductive? | Best For |
 |---|---|---|---|---|
-| FastRP | `gds.fastRP` | Community | Yes (with `randomSeed`) | Fast, scalable, production ML |
+| FastRP | `gds.fastRP` | Community | Yes (with `randomSeed`) | Fast production ML; structural vector search |
 | GraphSAGE | `gds.graphSage` | Community | Yes | Feature-rich nodes; generalizes to unseen nodes |
 | Node2Vec | `gds.node2vec` | Community | No (transductive) | Structural similarity; same graph train+predict |
 | HashGNN | `gds.hashgnn` | Community | Yes | GNN-style, limited compute, fast |

--- a/neo4j-graphrag-skill/SKILL.md
+++ b/neo4j-graphrag-skill/SKILL.md
@@ -28,6 +28,7 @@ allowed-tools: Bash WebFetch
 
 - **KG construction from documents** → `neo4j-document-import-skill`
 - **Plain vector/semantic search without graph traversal** → `neo4j-vector-index-skill`
+- **Hybrid search that combines vector with fulltext or other ranked sources** → `neo4j-vector-index-skill`
 - **GDS algorithms (PageRank, Louvain, node embeddings)** → `neo4j-gds-skill`
 - **Agent long-term memory** → `neo4j-agent-memory-skill`
 - **Writing raw Cypher queries** → `neo4j-cypher-skill`
@@ -78,6 +79,8 @@ Using external vector DB?       → WeaviateNeo4jRetriever / PineconeNeo4jRetrie
 | `HybridCypherRetriever` | ✓ | ✓ | ✓ | **Production GraphRAG — default choice** |
 | `Text2CypherRetriever` | — | — | ✓ | LLM generates Cypher; no embedder |
 | `ToolsRetriever` | varies | varies | varies | Multi-retriever LLM routing |
+
+For custom Cypher hybrid search outside the `neo4j-graphrag` retriever APIs, use `neo4j-vector-index-skill`.
 
 ---
 

--- a/neo4j-vector-index-skill/README.md
+++ b/neo4j-vector-index-skill/README.md
@@ -1,6 +1,6 @@
 # neo4j-vector-index-skill
 
-Skill for creating and querying vector indexes in Neo4j for semantic similarity search.
+Skill for creating and querying vector indexes in Neo4j for semantic or structural similarity search.
 
 **Covers:**
 - Creating vector indexes: `CREATE VECTOR INDEX` with dimensions and similarity function
@@ -10,7 +10,8 @@ Skill for creating and querying vector indexes in Neo4j for semantic similarity 
 - Batch embedding procedure `ai.text.embedBatch()` for large datasets
 - Vector search: `SEARCH` clause [2026.01+] and `db.index.vector.queryNodes()` procedure fallback
 - Combining vector search with graph traversal (hybrid retrieval)
-- Hybrid search, including vector + fulltext or multiple ranked sources
+- Hybrid search, including semantic + lexical + structural sources
+- Vector indexes over embeddings already written by GDS algorithms
 - Chunking strategy before ingestion (fixed-size, sentence, semantic)
 - Similarity function guidance: cosine vs euclidean — match your model's training loss
 - Common errors: wrong dimensions, index not ONLINE, provider null returns
@@ -24,7 +25,7 @@ Skill for creating and querying vector indexes in Neo4j for semantic similarity 
 - Full `ai.text.*` plugin reference (completion, chat, structured output) → `neo4j-genai-plugin-skill`
 - GraphRAG pipelines with `neo4j-graphrag` → `neo4j-graphrag-skill`
 - Fulltext-only / keyword-only search → `neo4j-cypher-skill`
-- GDS node embedding algorithms (FastRP, GraphSAGE) → `neo4j-gds-skill`
+- Computing GDS node embedding algorithms (FastRP, GraphSAGE) → `neo4j-gds-skill`
 
 **Install:**
 ```bash

--- a/neo4j-vector-index-skill/README.md
+++ b/neo4j-vector-index-skill/README.md
@@ -10,6 +10,7 @@ Skill for creating and querying vector indexes in Neo4j for semantic similarity 
 - Batch embedding procedure `ai.text.embedBatch()` for large datasets
 - Vector search: `SEARCH` clause [2026.01+] and `db.index.vector.queryNodes()` procedure fallback
 - Combining vector search with graph traversal (hybrid retrieval)
+- Hybrid search, including vector + fulltext or multiple ranked sources
 - Chunking strategy before ingestion (fixed-size, sentence, semantic)
 - Similarity function guidance: cosine vs euclidean — match your model's training loss
 - Common errors: wrong dimensions, index not ONLINE, provider null returns
@@ -22,6 +23,7 @@ Skill for creating and querying vector indexes in Neo4j for semantic similarity 
 **Not covered:**
 - Full `ai.text.*` plugin reference (completion, chat, structured output) → `neo4j-genai-plugin-skill`
 - GraphRAG pipelines with `neo4j-graphrag` → `neo4j-graphrag-skill`
+- Fulltext-only / keyword-only search → `neo4j-cypher-skill`
 - GDS node embedding algorithms (FastRP, GraphSAGE) → `neo4j-gds-skill`
 
 **Install:**

--- a/neo4j-vector-index-skill/SKILL.md
+++ b/neo4j-vector-index-skill/SKILL.md
@@ -5,11 +5,11 @@ description: Create and manage Neo4j vector indexes, run vector similarity searc
   db.index.vector.queryNodes() procedure (deprecated 2026.04, still works on 2025.x), configure
   HNSW and quantization options, pick similarity function and embedding provider dimensions, and
   batch-update embeddings. Use when tasks involve CREATE VECTOR INDEX, vector.dimensions,
-  cosine/euclidean search, embedding ingestion pipelines, semantic nearest-neighbor lookup, or
-  hybrid search (commonly combining vector and fulltext results).
+  cosine/euclidean search, embedding ingestion pipelines, semantic or structural nearest-neighbor
+  lookup, or hybrid search (vector + fulltext, multiple vector sources, or graph-derived scores).
   Does NOT handle GraphRAG retrieval_query graph traversal — use neo4j-graphrag-skill.
   Does NOT handle fulltext-only/keyword-only search — use neo4j-cypher-skill.
-  Does NOT handle GDS graph embeddings (FastRP, Node2Vec) — use neo4j-gds-skill.
+  Does NOT compute GDS graph embeddings (FastRP, Node2Vec) — use neo4j-gds-skill.
 version: 1.0.0
 compatibility: Neo4j >= 2025.01; SEARCH clause requires 2026.01+
 allowed-tools: Bash WebFetch
@@ -19,6 +19,7 @@ allowed-tools: Bash WebFetch
 - Creating a vector index (`CREATE VECTOR INDEX`) on nodes or relationships
 - Running vector similarity / nearest-neighbor search
 - Storing embeddings on graph nodes during ingestion
+- Indexing/querying embeddings already written by GDS algorithms
 - Choosing similarity function, dimensions, HNSW params, or quantization
 - Using `SEARCH` clause (2026.01+) or `db.index.vector.queryNodes()` (2025.x)
 - Batch-updating embeddings after model change
@@ -28,7 +29,7 @@ allowed-tools: Bash WebFetch
 ## When NOT to Use
 - **GraphRAG pipelines** (VectorCypherRetriever, HybridCypherRetriever, retrieval_query) → `neo4j-graphrag-skill`
 - **Fulltext-only / keyword-only search** (FULLTEXT INDEX, `db.index.fulltext.queryNodes`) → `neo4j-cypher-skill`
-- **GDS graph embeddings** (FastRP, Node2Vec, GraphSAGE) → `neo4j-gds-skill`
+- **Computing GDS graph embeddings** (FastRP, Node2Vec, GraphSAGE) → `neo4j-gds-skill`
 - **Index admin** (list all indexes, drop range/text/lookup indexes) → `neo4j-cypher-skill`
 
 ---
@@ -261,8 +262,8 @@ For full retrieval_query pipelines, HybridCypherRetriever, or `neo4j-graphrag` l
 
 ## Step 6 — Hybrid Search
 
-Use hybrid search when vector-only misses exact terms, codes, acronyms, or names, or when fulltext-only misses paraphrases and semantic matches.
-The common pattern is vector + fulltext, but the same approach works for several vector indexes, graph traversal scores, or any two+ ranked/scored sources.
+Use hybrid search when one signal misses useful candidates: semantic vectors miss exact terms, lexical fulltext misses paraphrases, structural graph signals find topology not present in text.
+The common pattern is vector + fulltext, but the same approach works for several vector indexes, GDS-written embeddings, graph traversal scores, or any two+ ranked/scored sources.
 Load [references/hybrid-search.md](references/hybrid-search.md) and apply its query shape.
 
 Rules:
@@ -477,7 +478,7 @@ If both return `null` → embeddings not set. If cosine returns `1.0` → identi
 
 ## References
 Load on demand:
-- [Hybrid search](references/hybrid-search.md) - combine vector + fulltext or multiple ranked sources with WRRF/RRF
+- [Hybrid search](references/hybrid-search.md) - combine semantic, lexical, structural, or other ranked sources with WRRF/RRF
 - [Vector index docs](https://neo4j.com/docs/cypher-manual/25/indexes/semantic-indexes/vector-indexes/)
 - [SEARCH clause docs](https://neo4j.com/docs/cypher-manual/25/clauses/search/)
 - [Vector functions docs](https://neo4j.com/docs/cypher-manual/25/functions/vector/)

--- a/neo4j-vector-index-skill/SKILL.md
+++ b/neo4j-vector-index-skill/SKILL.md
@@ -5,9 +5,10 @@ description: Create and manage Neo4j vector indexes, run vector similarity searc
   db.index.vector.queryNodes() procedure (deprecated 2026.04, still works on 2025.x), configure
   HNSW and quantization options, pick similarity function and embedding provider dimensions, and
   batch-update embeddings. Use when tasks involve CREATE VECTOR INDEX, vector.dimensions,
-  cosine/euclidean search, embedding ingestion pipelines, or semantic nearest-neighbor lookup.
+  cosine/euclidean search, embedding ingestion pipelines, semantic nearest-neighbor lookup, or
+  hybrid search (commonly combining vector and fulltext results).
   Does NOT handle GraphRAG retrieval_query graph traversal — use neo4j-graphrag-skill.
-  Does NOT handle fulltext/keyword indexes (FULLTEXT INDEX, db.index.fulltext) — use neo4j-cypher-skill.
+  Does NOT handle fulltext-only/keyword-only search — use neo4j-cypher-skill.
   Does NOT handle GDS graph embeddings (FastRP, Node2Vec) — use neo4j-gds-skill.
 version: 1.0.0
 compatibility: Neo4j >= 2025.01; SEARCH clause requires 2026.01+
@@ -22,10 +23,11 @@ allowed-tools: Bash WebFetch
 - Using `SEARCH` clause (2026.01+) or `db.index.vector.queryNodes()` (2025.x)
 - Batch-updating embeddings after model change
 - Combining vector results with immediate graph neighborhood (full retrieval_query pipelines → `neo4j-graphrag-skill`)
+- Hybrid search that combines vector results with fulltext or other ranked sources
 
 ## When NOT to Use
 - **GraphRAG pipelines** (VectorCypherRetriever, HybridCypherRetriever, retrieval_query) → `neo4j-graphrag-skill`
-- **Fulltext / keyword search** (FULLTEXT INDEX, `db.index.fulltext.queryNodes`) → `neo4j-cypher-skill`
+- **Fulltext-only / keyword-only search** (FULLTEXT INDEX, `db.index.fulltext.queryNodes`) → `neo4j-cypher-skill`
 - **GDS graph embeddings** (FastRP, Node2Vec, GraphSAGE) → `neo4j-gds-skill`
 - **Index admin** (list all indexes, drop range/text/lookup indexes) → `neo4j-cypher-skill`
 
@@ -257,6 +259,22 @@ For full retrieval_query pipelines, HybridCypherRetriever, or `neo4j-graphrag` l
 
 ---
 
+## Step 6 — Hybrid Search
+
+Use hybrid search when vector-only misses exact terms, codes, acronyms, or names, or when fulltext-only misses paraphrases and semantic matches.
+The common pattern is vector + fulltext, but the same approach works for several vector indexes, graph traversal scores, or any two+ ranked/scored sources.
+Load [references/hybrid-search.md](references/hybrid-search.md) and apply its query shape.
+
+Rules:
+- Run each source independently; rank each by `score DESC, stable_id ASC`.
+- Combine by rank, not raw scores; fulltext and vector scores are not comparable.
+- Every `UNION ALL` branch returns same columns: matched node + contribution.
+- Use `sourceK > finalK`; combine before final limiting.
+- Sum contributions per node; order final rows by `wrrf DESC, stable_id ASC`.
+- Add more sources with extra `UNION ALL` branches and new `sourceWeights` keys.
+
+---
+
 ## Embedding Provider Quick-Reference
 
 | Provider / Model | Dimensions | Similarity | Notes |
@@ -459,6 +477,7 @@ If both return `null` → embeddings not set. If cosine returns `1.0` → identi
 
 ## References
 Load on demand:
+- [Hybrid search](references/hybrid-search.md) - combine vector + fulltext or multiple ranked sources with WRRF/RRF
 - [Vector index docs](https://neo4j.com/docs/cypher-manual/25/indexes/semantic-indexes/vector-indexes/)
 - [SEARCH clause docs](https://neo4j.com/docs/cypher-manual/25/clauses/search/)
 - [Vector functions docs](https://neo4j.com/docs/cypher-manual/25/functions/vector/)

--- a/neo4j-vector-index-skill/references/hybrid-search.md
+++ b/neo4j-vector-index-skill/references/hybrid-search.md
@@ -1,10 +1,13 @@
 # Hybrid Search
 
-Hybrid search is useful when one retrieval signal is not enough. Vector search finds semantic matches and paraphrases, but can miss exact names, acronyms, codes, and domain-specific terms. Fulltext search finds exact lexical matches, but can miss related concepts that do not share the same words.
+Hybrid search is useful when one retrieval signal is not enough:
+- Semantic vector search finds paraphrases; misses exact names, acronyms, codes, and domain terms.
+- Lexical fulltext search finds exact words; misses related concepts that do not share words.
+- Structural search uses graph topology, paths, communities, or GDS node embeddings; captures relationships text does not contain.
 
-Combining ranked sources improves recall and can boost results that are supported by more than one signal. The common pattern is vector + fulltext, but the same query shape works for any two or more ranked/scored sources: several vector indexes, title/body fulltext indexes, graph-derived candidate scores, or external retrieval scores.
+Combining ranked sources improves recall and can boost results that are supported by more than one signal. The common pattern is vector + fulltext, but the same query shape works for any two or more ranked/scored sources: several vector indexes, title/body fulltext indexes, GDS-written structural embeddings, graph-derived candidate scores, or external retrieval scores.
 
-Use when the user asks for custom Cypher hybrid search, WRRF/RRF, vector + fulltext, multiple vector indexes, or combining two+ ranked/scored retrieval sources.
+Use when the user asks for custom Cypher hybrid search, WRRF/RRF, vector + fulltext, semantic + lexical + structural search, multiple vector indexes, or combining two+ ranked/scored retrieval sources.
 
 ## When NOT to Use
 - `neo4j-graphrag` package `HybridRetriever` / `HybridCypherRetriever` -> use `neo4j-graphrag-skill`
@@ -21,6 +24,7 @@ Use when the user asks for custom Cypher hybrid search, WRRF/RRF, vector + fullt
 - Use `sourceK > finalK`; combine before final limiting.
 - Use stable unique property for tie breaks. If no stable key exists, add one before production use.
 - Keep `LIMIT $sourceK` inside `SEARCH`; Cypher rejects a `LET` alias there.
+- For structural vector sources, compute/write GDS embeddings first, then create a vector index over that property.
 
 ## Index Setup
 
@@ -122,12 +126,14 @@ RETURN
 
 Examples:
 - second vector index with different embedding model -> `sourceWeights['vector_large']`
+- vector index over GDS FastRP/Node2Vec embeddings -> `sourceWeights['structural_vector']`
 - fulltext index over title fields -> `sourceWeights['title_fulltext']`
 - graph-derived candidate score converted to source rank -> `sourceWeights['graph']`
 
 ## Checklist
 - [ ] Vector and fulltext indexes `ONLINE`
 - [ ] Query embedding generated with same model as stored embeddings
+- [ ] Structural embeddings/scores already produced before query
 - [ ] `sourceK` larger than `finalK`
 - [ ] Stable unique property used for tie-breaks
 - [ ] Raw scores not compared across sources

--- a/neo4j-vector-index-skill/references/hybrid-search.md
+++ b/neo4j-vector-index-skill/references/hybrid-search.md
@@ -1,0 +1,135 @@
+# Hybrid Search
+
+Hybrid search is useful when one retrieval signal is not enough. Vector search finds semantic matches and paraphrases, but can miss exact names, acronyms, codes, and domain-specific terms. Fulltext search finds exact lexical matches, but can miss related concepts that do not share the same words.
+
+Combining ranked sources improves recall and can boost results that are supported by more than one signal. The common pattern is vector + fulltext, but the same query shape works for any two or more ranked/scored sources: several vector indexes, title/body fulltext indexes, graph-derived candidate scores, or external retrieval scores.
+
+Use when the user asks for custom Cypher hybrid search, WRRF/RRF, vector + fulltext, multiple vector indexes, or combining two+ ranked/scored retrieval sources.
+
+## When NOT to Use
+- `neo4j-graphrag` package `HybridRetriever` / `HybridCypherRetriever` -> use `neo4j-graphrag-skill`
+- Fulltext-only / keyword-only search -> use `neo4j-cypher-skill`
+- Single vector search -> use main `neo4j-vector-index-skill`
+
+## Rules
+- Run each source independently.
+- Rank each source by `score DESC, stable_id ASC`.
+- Do not compare raw scores from different sources.
+- Compute `contribution = sourceWeight / (rrfConstant + sourceRank)`.
+- Sum contributions per node.
+- Order final rows by `wrrf DESC, stable_id ASC`.
+- Use `sourceK > finalK`; combine before final limiting.
+- Use stable unique property for tie breaks. If no stable key exists, add one before production use.
+- Keep `LIMIT $sourceK` inside `SEARCH`; Cypher rejects a `LET` alias there.
+
+## Index Setup
+
+Vector index:
+```cypher
+CYPHER 25
+CREATE VECTOR INDEX chunk_embedding IF NOT EXISTS
+FOR (c:Chunk) ON (c.embedding)
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 1536,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+```
+
+Fulltext index:
+```cypher
+CYPHER 25
+CREATE FULLTEXT INDEX chunk_fulltext IF NOT EXISTS
+FOR (c:Chunk) ON EACH [c.text];
+```
+
+If fulltext analyzer, multi-property, or Lucene query syntax details matter, load `neo4j-cypher-skill`.
+
+## Parameters
+
+```json
+{
+  "query": "graph database search",
+  "queryVector": [0.12, -0.03, 0.45],
+  "sourceK": 20,
+  "finalK": 10,
+  "rrfConstant": 60.0,
+  "sourceWeights": {
+    "fulltext": 1.0,
+    "vector": 1.0
+  }
+}
+```
+
+## Query Template
+
+```cypher
+CYPHER 25
+LET
+  query = $query,
+  queryVector = $queryVector,
+  sourceK = $sourceK,
+  finalK = $finalK,
+  rrfConstant = $rrfConstant,
+  sourceWeights = $sourceWeights
+
+CALL (query, queryVector, sourceK, rrfConstant, sourceWeights) {
+  CALL db.index.fulltext.queryNodes('chunk_fulltext', query, {limit: sourceK})
+  YIELD node AS chunk, score
+  ORDER BY score DESC, chunk.id ASC
+  WITH collect(chunk) AS chunks, rrfConstant, sourceWeights
+  LET weight = coalesce(sourceWeights['fulltext'], 1.0)
+  UNWIND CASE WHEN size(chunks) = 0 THEN [] ELSE range(0, size(chunks) - 1) END AS rankIndex
+  RETURN
+    chunks[rankIndex] AS chunk,
+    weight / (rrfConstant + rankIndex + 1) AS contribution
+
+  UNION ALL
+
+  MATCH (chunk:Chunk)
+    SEARCH chunk IN (
+      VECTOR INDEX chunk_embedding
+      FOR queryVector
+      LIMIT $sourceK
+    ) SCORE AS score
+  ORDER BY score DESC, chunk.id ASC
+  WITH collect(chunk) AS chunks, rrfConstant, sourceWeights
+  LET weight = coalesce(sourceWeights['vector'], 1.0)
+  UNWIND CASE WHEN size(chunks) = 0 THEN [] ELSE range(0, size(chunks) - 1) END AS rankIndex
+  RETURN
+    chunks[rankIndex] AS chunk,
+    weight / (rrfConstant + rankIndex + 1) AS contribution
+}
+WITH chunk, finalK, sum(contribution) AS wrrf
+ORDER BY wrrf DESC, chunk.id ASC
+WITH collect({chunk: chunk, wrrf: wrrf}) AS orderedRows, finalK
+LET limitedRows = orderedRows[..finalK]
+UNWIND limitedRows AS row
+RETURN row.chunk.id AS id, row.chunk.text AS text, row.wrrf AS wrrf
+ORDER BY row.wrrf DESC, row.chunk.id ASC;
+```
+
+## Add More Sources
+
+Add one `UNION ALL` branch per source. Each branch must return:
+
+```cypher
+RETURN
+  matchedNode AS chunk,
+  weight / (rrfConstant + rankIndex + 1) AS contribution
+```
+
+Examples:
+- second vector index with different embedding model -> `sourceWeights['vector_large']`
+- fulltext index over title fields -> `sourceWeights['title_fulltext']`
+- graph-derived candidate score converted to source rank -> `sourceWeights['graph']`
+
+## Checklist
+- [ ] Vector and fulltext indexes `ONLINE`
+- [ ] Query embedding generated with same model as stored embeddings
+- [ ] `sourceK` larger than `finalK`
+- [ ] Stable unique property used for tie-breaks
+- [ ] Raw scores not compared across sources
+- [ ] Missing source weights intentionally default to `1.0`
+- [ ] Additional source branches return same columns


### PR DESCRIPTION
## Summary

- add hybrid search guidance to the vector index skill
- route custom Cypher hybrid search away from the Cypher and GraphRAG skills to the vector index skill
- add a focused hybrid-search reference with value framing and a WRRF/RRF query template for combining vector, fulltext, or other ranked sources

## Validation

- python3 scripts/lint_skills.py
- git diff --cached --check
