### PR TITLE
update(graphrag): refresh skills for neo4j-graphrag v1.16.0

### DIFF
--- a/neo4j-document-import-skill/SKILL.md
+++ b/neo4j-document-import-skill/SKILL.md
@@ -51,15 +51,19 @@ allowed-tools: Bash WebFetch
 ## Install
 
 ```bash
-pip install neo4j-graphrag              # includes SimpleKGPipeline
-pip install neo4j-graphrag[openai]      # + OpenAI LLM/embedder
-pip install neo4j-graphrag[anthropic]   # + Anthropic Claude
-pip install neo4j-graphrag[google]      # + Vertex AI / Gemini
+pip install neo4j-graphrag                   # includes SimpleKGPipeline
+pip install neo4j-graphrag[openai]           # + OpenAI LLM/embedder
+pip install neo4j-graphrag[anthropic]        # + Anthropic Claude
+pip install neo4j-graphrag[google]           # + Vertex AI / Gemini
+pip install neo4j-graphrag[bedrock]          # + Amazon Bedrock (boto3) — added v1.15.0
+pip install neo4j-graphrag[ollama]           # + Ollama (local)
+pip install neo4j-graphrag[mistralai]        # + MistralAI
+pip install neo4j-graphrag[fuzzy-matching]   # + FuzzyMatchResolver (rapidfuzz)
 # spaCy entity resolver (Python <= 3.13 only — unsupported on 3.14+):
 pip install neo4j-graphrag[nlp]
 ```
 
-Requires: `neo4j>=6.0.0`, Python>=3.10, Neo4j>=5.18.1 (Aura>=5.18.0).
+Requires: `neo4j>=5.17.0` (driver 6.x supported), Python>=3.10, Neo4j>=5.18.1 (Aura>=5.18.0).
 
 ---
 
@@ -78,20 +82,39 @@ patterns = [
     ("Article", "MENTIONS", "Organization"),
 ]
 
-# Option B — Rich schema (better extraction quality)
+# Option B — Rich GraphSchema (production; best extraction quality)
 from neo4j_graphrag.experimental.components.schema import (
-    SchemaBuilder, SchemaEntity, SchemaRelation
+    GraphSchema, NodeType, RelationshipType, PropertyType, ConstraintType
 )
-schema = SchemaBuilder().create_schema_from_dict({
-    "entities": {
-        "Person": {"description": "A human individual", "properties": {"name": "str", "role": "str"}},
-        "Organization": {"description": "A company or institution", "properties": {"name": "str", "industry": "str"}},
-    },
-    "relations": {
-        "WORKS_AT": {"description": "Employment relationship"},
-    },
-    "patterns": [("Person", "WORKS_AT", "Organization")],
-})
+schema = GraphSchema(
+    node_types=[
+        NodeType(
+            label="Person",
+            description="A human individual",
+            properties=[
+                PropertyType(name="name", type="STRING"),
+                PropertyType(name="role", type="STRING"),
+            ],
+        ),
+        NodeType(
+            label="Organization",
+            description="A company or institution",
+            properties=[
+                PropertyType(name="name", type="STRING"),
+                PropertyType(name="industry", type="STRING"),
+            ],
+        ),
+    ],
+    relationship_types=[
+        RelationshipType(label="WORKS_AT", description="Employment relationship"),
+    ],
+    patterns=[("Person", "WORKS_AT", "Organization")],
+    # Optional: constraints emitted to ParquetWriter metadata (v1.15.0+)
+    constraints=[
+        ConstraintType(label="Person", property_name="name", type="UNIQUENESS"),
+        ConstraintType(label="Organization", property_name="name", type="KEY"),
+    ],
+)
 
 # Option C — Auto-extract schema from text (no constraints)
 schema = "EXTRACTED"   # LLM infers types; noisier output
@@ -117,8 +140,10 @@ driver = GraphDatabase.driver(
 )
 
 llm = OpenAILLM(
-    model_name="gpt-4o",
-    model_params={"temperature": 0, "response_format": {"type": "json_object"}},
+    model_name="gpt-4.1",
+    model_params={"temperature": 0},
+    # Note: SimpleKGPipeline auto-enables structured output for OpenAI/VertexAI LLMs (v1.14.0+)
+    # Do NOT set response_format manually — it is managed by the pipeline
 )
 embedder = OpenAIEmbeddings()   # OPENAI_API_KEY from env
 
@@ -126,9 +151,7 @@ pipeline = SimpleKGPipeline(
     llm=llm,
     driver=driver,
     embedder=embedder,
-    entities=entities,          # from Step 1
-    relations=relations,
-    patterns=patterns,
+    schema=schema,              # GraphSchema, dict, "FREE", or "EXTRACTED"
     from_file=True,             # False → pass text= instead of file_path=
     on_error="IGNORE",          # RAISE to surface extraction failures
     perform_entity_resolution=True,
@@ -138,19 +161,30 @@ pipeline = SimpleKGPipeline(
 
 **LLM alternatives** (same interface):
 - `AnthropicLLM(model_name="claude-3-5-sonnet-20241022")`
-- `VertexAILLM(model_name="gemini-1.5-pro-002")`
+- `VertexAILLM(model_name="gemini-2.0-flash")`
 - `OllamaLLM(model_name="llama3")` — local; no API key needed
+- `BedrockLLM(model_id="anthropic.claude-3-5-sonnet-20241022-v2:0")` — Amazon Bedrock (v1.15.0+)
 
 ---
 
 ## Step 3 — Run the Pipeline
 
 ```python
-# From PDF or Markdown file:
+# From PDF file:
 result = asyncio.run(pipeline.run_async(
-    file_path="report.pdf",
+    file_path="report.pdf",        # auto-dispatches to PdfLoader
     document_metadata={"source": "Q4 report", "year": 2025},
 ))
+
+# From Markdown file (v1.15.0+):
+result = asyncio.run(pipeline.run_async(
+    file_path="notes.md",          # auto-dispatches to MarkdownLoader
+    document_metadata={"source": "meeting notes"},
+))
+
+# Note: old `from_pdf=True` parameter is DEPRECATED since v1.15.0; use `from_file=True` instead
+# pipeline = SimpleKGPipeline(..., from_file=True)   ← correct
+# pipeline = SimpleKGPipeline(..., from_pdf=True)    ← deprecated
 
 # From raw text:
 result = asyncio.run(pipeline.run_async(
@@ -403,7 +437,10 @@ If rows returned: wait, then re-run. ONLINE = safe to ingest.
 | Chunking loses sentence mid-way | `approximate=False` (default) cuts at exact token count | Set `approximate=True` in `FixedSizeSplitter` |
 | `chunk_size` too large → LLM timeouts | Extraction prompt + chunk exceeds context | Keep chunk_size ≤ 512 for GPT-4o extraction; ≤ 2048 absolute max |
 | `SpaCySemanticMatchResolver` fails on Python 3.14 | spaCy not supported on 3.14+ | Use `FuzzyMatchResolver` or downgrade to Python 3.13 |
-| `neo4j-driver` package not found | Deprecated package name since 6.0 | Use `neo4j` package: `pip install neo4j>=6.0.0` |
+| `neo4j-driver` package not found | Deprecated package name since 6.0 | Use `neo4j` package: `pip install neo4j>=5.17.0` |
+| `ValidationError` on `NodeType` with no properties | `NodeType` requires ≥1 property since v1.13.0 | Add at least `PropertyType(name="name", type="STRING")`; string-list labels get it automatically |
+| `from_pdf` deprecation warning | `from_pdf=True` removed in v1.15.0 | Use `from_file=True` instead |
+| `response_format` in `model_params` ignored | `SimpleKGPipeline` auto-enables structured output for OpenAI/VertexAI (v1.14.0+) | Remove `response_format` from `model_params`; the pipeline manages it |
 
 ---
 
@@ -423,14 +460,16 @@ If rows returned: wait, then re-run. ONLINE = safe to ingest.
 
 ---
 
-## GraphSchema — Current API (≥1.7.1)
+## GraphSchema — Current API (≥1.8.0)
 
-`entities`/`relations`/`potential_schema` deprecated since 1.7.1. Use `schema=GraphSchema(...)`:
+`entities`/`relations`/`potential_schema` are deprecated. Use `schema=GraphSchema(...)`.
 
 ```python
 from neo4j_graphrag.experimental.components.schema import (
-    GraphSchema, NodeType, RelationshipType, PropertyType
+    GraphSchema, NodeType, RelationshipType, PropertyType,
+    ConstraintType, GraphConstraintType,
 )
+
 schema = GraphSchema(
     node_types=[
         NodeType(label="Person", properties=[PropertyType(name="name", type="STRING")]),
@@ -438,11 +477,57 @@ schema = GraphSchema(
     ],
     relationship_types=[RelationshipType(label="WORKS_AT")],
     patterns=[("Person", "WORKS_AT", "Organization")],
+    # Constraints (v1.15.0+) — emitted to ParquetWriter metadata and enforce schema
+    constraints=[
+        # UNIQUENESS — property must be unique across nodes of that label
+        ConstraintType(label="Person", property_name="name", type=GraphConstraintType.UNIQUENESS),
+        # KEY — uniqueness + existence (null not allowed)
+        ConstraintType(label="Organization", property_name="name", type=GraphConstraintType.KEY),
+        # EXISTENCE — property must be non-null (replaces deprecated PropertyType.required)
+        ConstraintType(label="Event", property_name="date", type=GraphConstraintType.EXISTENCE),
+        # Composite KEY (v1.15.0+)
+        ConstraintType(
+            label="Person",
+            property_names=("first_name", "last_name"),
+            type=GraphConstraintType.KEY,
+        ),
+    ],
 )
 pipeline = SimpleKGPipeline(llm=llm, driver=driver, embedder=embedder, schema=schema)
 ```
 
-`schema="FREE"` (no guidance) or `schema="EXTRACTED"` (LLM infers) — exploration only, noisier output.
+`schema="FREE"` (no guidance) or `schema="EXTRACTED"` (LLM infers types) — exploration only, noisier output.
+
+### Auto-Extract Schema from Text (v1.15.0+)
+
+When no `schema` is passed to `SimpleKGPipeline`, `SchemaFromTextExtractor` runs automatically.
+To run it explicitly:
+
+```python
+from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+    SchemaFromTextExtractor,
+    SchemaFromExistingGraphExtractor,
+)
+
+# Infer schema from sample text
+extractor = SchemaFromTextExtractor(llm=llm, use_structured_output=True)
+schema = asyncio.run(extractor.run(text=sample_text))
+
+# Derive schema from an existing Neo4j graph
+extractor = SchemaFromExistingGraphExtractor(driver=driver)
+schema = asyncio.run(extractor.run())
+```
+
+### Parquet Export (experimental, v1.14.0+)
+
+```python
+from neo4j_graphrag.experimental.components.parquet_output import ParquetWriter
+
+# Use ParquetWriter instead of KGWriter inside a Pipeline to export to Parquet files
+writer = ParquetWriter(output_dir="/data/kg_export/")
+# Produces one Parquet file per node label and per relationship type
+# Metadata includes UNIQUENESS, EXISTENCE, and KEY constraints (v1.15.0/1.16.0)
+```
 
 ---
 

--- a/neo4j-graphrag-skill/SKILL.md
+++ b/neo4j-graphrag-skill/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: neo4j-graphrag-skill
 description: Build GraphRAG retrieval pipelines on Neo4j using the neo4j-graphrag Python
-  package (formerly neo4j-genai). Covers retriever selection (VectorRetriever,
-  HybridRetriever, VectorCypherRetriever, HybridCypherRetriever, Text2CypherRetriever),
-  retrieval_query Cypher fragments, query_params, pipeline wiring (GraphRAG + LLM),
-  embedder setup, index creation, and LangChain/LlamaIndex integration. Does NOT handle
-  KG construction from documents — use neo4j-document-import-skill. Does NOT handle
-  plain vector search — use neo4j-vector-index-skill. Does NOT handle GDS analytics —
-  use neo4j-gds-skill. Does NOT handle agent memory — use neo4j-agent-memory-skill.
-version: 1.0.0
+  package (v1.16.0+). Covers retriever selection (VectorRetriever, HybridRetriever,
+  VectorCypherRetriever, HybridCypherRetriever, Text2CypherRetriever, ToolsRetriever),
+  external vector DB retrievers (Weaviate, Pinecone, Qdrant), retrieval_query Cypher
+  fragments, query_params, filters, GraphRAG pipeline wiring (GraphRAG + LLM + prompt),
+  all LLM providers (OpenAI, Anthropic, VertexAI, Bedrock, Cohere, Mistral, Ollama),
+  embedder setup, index creation, token usage tracking, Cypher 25 SEARCH clause, and
+  LangChain/LlamaIndex integration. Does NOT handle KG construction — use
+  neo4j-document-import-skill. Does NOT handle plain vector search — use
+  neo4j-vector-index-skill. Does NOT handle GDS analytics — use neo4j-gds-skill.
+  Does NOT handle agent memory — use neo4j-agent-memory-skill.
+version: 1.1.0
 status: active
 allowed-tools: Bash WebFetch
 ---
@@ -19,10 +22,11 @@ allowed-tools: Bash WebFetch
 
 - Building GraphRAG retrieval pipelines with `neo4j-graphrag` Python package
 - Choosing between VectorRetriever, HybridRetriever, VectorCypherRetriever, HybridCypherRetriever
-- Writing `retrieval_query` Cypher fragments that traverse the graph after vector lookup
+- Writing `retrieval_query` Cypher fragments for graph-augmented context
 - Wiring retriever + LLM into a `GraphRAG` pipeline
-- Debugging low retrieval quality (when to use graph traversal vs plain vector)
-- Integrating Neo4j with LangChain (`langchain-neo4j`), LlamaIndex, or Haystack
+- Using LLM-routed multi-retriever with `ToolsRetriever`
+- Debugging low retrieval quality
+- Integrating Neo4j with LangChain, LlamaIndex, or Haystack
 
 ## When NOT to Use
 
@@ -35,25 +39,52 @@ allowed-tools: Bash WebFetch
 
 ---
 
-## Step 1 — Install
+## Retriever Selection
 
-```bash
-pip install neo4j-graphrag
-# LLM/embedder extras (choose one or more):
-pip install neo4j-graphrag[openai]        # OpenAI + AzureOpenAI
-pip install neo4j-graphrag[google]        # VertexAI
-pip install neo4j-graphrag[anthropic]     # Anthropic
-pip install neo4j-graphrag[ollama]        # Ollama (local)
-pip install neo4j-graphrag[cohere]        # Cohere
-pip install neo4j-graphrag[sentence-transformers]  # local embeddings
+```
+Has fulltext index?
+  YES → Hybrid variants (HybridRetriever / HybridCypherRetriever)
+  NO  → Vector variants (VectorRetriever / VectorCypherRetriever)
 
-# BREAKING: old package `neo4j-genai` is deprecated — imports also changed:
-pip uninstall neo4j-genai
-# neo4j_genai.retrievers → neo4j_graphrag.retrievers
-# neo4j_genai.generation → neo4j_graphrag.generation
+Need graph traversal after vector lookup?
+  YES → Cypher variants (VectorCypherRetriever / HybridCypherRetriever)
+  NO  → plain variants
+
+Natural-language-to-Cypher?        → Text2CypherRetriever (no embedder needed)
+LLM should route between retrievers? → ToolsRetriever
+Vectors stored in external DB?      → WeaviateNeo4jRetriever / PineconeNeo4jRetriever / QdrantNeo4jRetriever
 ```
 
-Requires: Python ≥ 3.10, Neo4j ≥ 5.18.1 or Aura ≥ 5.18.0.
+| Retriever | Vector | Fulltext | Graph | Best For |
+|---|:---:|:---:|:---:|---|
+| `VectorRetriever` | ✓ | — | — | Baseline semantic search |
+| `HybridRetriever` | ✓ | ✓ | — | Better recall, no graph expansion |
+| `VectorCypherRetriever` | ✓ | — | ✓ | GraphRAG without fulltext |
+| `HybridCypherRetriever` | ✓ | ✓ | ✓ | **Production GraphRAG — default** |
+| `Text2CypherRetriever` | — | — | ✓ | NL→Cypher, no embedder |
+| `ToolsRetriever` | varies | varies | varies | LLM-routed multi-retriever |
+| `WeaviateNeo4jRetriever` | ✓ | — | ✓ | Vectors in Weaviate |
+| `PineconeNeo4jRetriever` | ✓ | — | ✓ | Vectors in Pinecone |
+| `QdrantNeo4jRetriever` | ✓ | — | ✓ | Vectors in Qdrant |
+
+---
+
+## Install
+
+```bash
+pip install neo4j-graphrag[openai]        # OpenAI LLM + embeddings
+pip install neo4j-graphrag[anthropic]     # Anthropic Claude
+pip install neo4j-graphrag[google]        # Vertex AI / Gemini
+pip install neo4j-graphrag[bedrock]       # Amazon Bedrock (boto3)
+pip install neo4j-graphrag[cohere]        # Cohere
+pip install neo4j-graphrag[mistralai]     # MistralAI
+pip install neo4j-graphrag[ollama]        # Ollama (local)
+pip install neo4j-graphrag[weaviate]      # Weaviate external retriever
+pip install neo4j-graphrag[pinecone]      # Pinecone external retriever
+pip install neo4j-graphrag[qdrant]        # Qdrant external retriever
+```
+
+Requires: Python >= 3.10, `neo4j >= 5.17.0` (driver 6.x supported).
 
 ---
 
@@ -116,18 +147,17 @@ If index not ONLINE: wait, poll every 5s. Do NOT start ingestion until ONLINE.
 
 ```python
 from neo4j import GraphDatabase
-from neo4j_graphrag.retrievers import HybridCypherRetriever
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
 from neo4j_graphrag.generation import GraphRAG
 from neo4j_graphrag.llm import OpenAILLM
+from neo4j_graphrag.retrievers import HybridCypherRetriever
 
-driver = GraphDatabase.driver("neo4j+s://<host>:7687", auth=("neo4j", "<password>"))
-embedder = OpenAIEmbeddings(model="text-embedding-3-small")  # 1536 dims — match index
+driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
+embedder = OpenAIEmbeddings(model="text-embedding-3-large")  # OPENAI_API_KEY from env
 
-# retrieval_query: Cypher fragment executed after vector lookup.
-# `node` = matched node from vector index   (AUTO-INJECTED — do NOT declare)
-# `score` = similarity float                (AUTO-INJECTED — do NOT declare)
-# MUST include RETURN clause. MUST return `score` column.
+# retrieval_query: Cypher fragment executed after the vector/fulltext lookup.
+# Auto-injected variables:  node  (matched node)   score  (similarity float)
+# MUST include a RETURN clause.  score must appear in RETURN.
 retrieval_query = """
 MATCH (node)<-[:HAS_CHUNK]-(article:Article)
 OPTIONAL MATCH (article)-[:MENTIONS]->(org:Organization)
@@ -145,25 +175,27 @@ retriever = HybridCypherRetriever(
     embedder=embedder,
 )
 
-llm = OpenAILLM(model_name="gpt-4o", model_params={"temperature": 0})
-rag = GraphRAG(retriever=retriever, llm=llm)
+llm = OpenAILLM(model_name="gpt-4.1", model_params={"temperature": 0})
 
-response = rag.search(query_text="Who does Alice work for?", retriever_config={"top_k": 5})
+rag = GraphRAG(
+    retriever=retriever,
+    llm=llm,
+)
+
+response = rag.search(
+    query_text="Who does Alice work for?",
+    retriever_config={"top_k": 5},
+)
 print(response.answer)
+driver.close()
 ```
 
 ---
 
-## Step 5 — query_params (Parameterized retrieval_query)
-
-Pass runtime parameters into `retrieval_query` via `retriever_config`:
+## VectorCypherRetriever
 
 ```python
-retrieval_query = """
-MATCH (node)<-[:HAS_CHUNK]-(article:Article)-[:MENTIONS]->(org:Organization)
-WHERE org.name = $entity_name
-RETURN node.text AS chunk_text, article.title AS title, score
-"""
+from neo4j_graphrag.retrievers import VectorCypherRetriever
 
 retriever = VectorCypherRetriever(
     driver=driver,
@@ -172,87 +204,315 @@ retriever = VectorCypherRetriever(
     embedder=embedder,
 )
 
-# Pass query_params inside retriever_config on each search:
 response = rag.search(
     query_text="What happened at Apple?",
-    retriever_config={"top_k": 10, "query_params": {"entity_name": "Apple"}},
+    retriever_config={"top_k": 10},
 )
+```
 
-# Direct retriever call (without GraphRAG wrapper):
+---
+
+## Text2CypherRetriever
+
+Translates natural language to Cypher using an LLM. **No embedder required.**
+
+> **Security (v1.16.0+):** Every LLM-generated Cypher is run through `EXPLAIN` first.
+> Any statement classified as write/destructive raises `Text2CypherRetrievalError` instead
+> of executing — prevents prompt-injection attacks.
+
+```python
+from neo4j_graphrag.retrievers import Text2CypherRetriever
+
+retriever = Text2CypherRetriever(
+    driver=driver,
+    llm=OpenAILLM(model_name="gpt-4.1"),
+    neo4j_schema=None,       # None = auto-fetch schema from DB; pass string to trim
+    examples=[
+        "Q: Who works at Neo4j? A: MATCH (p:Person)-[:WORKS_AT]->(c:Company {name:'Neo4j'}) RETURN p.name"
+    ],
+)
+results = retriever.search(query_text="Which people work at Neo4j?")
+```
+
+---
+
+## ToolsRetriever (LLM-routed multi-retriever)
+
+```python
+from neo4j_graphrag.retrievers import ToolsRetriever
+
+tools_retriever = ToolsRetriever(
+    llm=llm,
+    retrievers=[vector_retriever, text2cypher_retriever],
+)
+# LLM decides which retriever(s) to invoke per query
+
+# Convert any retriever to a standalone Tool:
+tool = vector_retriever.convert_to_tool()
+```
+
+---
+
+## Filters (pre-filter before vector search)
+
+```python
+results = retriever.search(
+    query_text="quarterly earnings",
+    top_k=5,
+    filters={
+        "date": {"$gte": "2024-01-01"},
+        "source": {"$eq": "10-K"},
+    },
+)
+# Operators: $eq  $ne  $lt  $lte  $gt  $gte  $between  $in  $like  $ilike
+```
+
+---
+
+## query_params (parameterized retrieval_query)
+
+```python
+retrieval_query = """
+MATCH (node)<-[:HAS_CHUNK]-(a:Article)-[:MENTIONS]->(org:Organization {name: $entity_name})
+RETURN node.text, a.title, score
+"""
+
+# Pass via retriever.search directly:
 results = retriever.search(
     query_text="What happened at Apple?",
     top_k=10,
     query_params={"entity_name": "Apple"},
 )
-```
 
----
-
-## Step 6 — Filters (Pre-filter before vector search)
-
-```python
-# Filter reduces candidate pool BEFORE vector similarity ranking
-results = retriever.search(
-    query_text="quarterly results",
-    top_k=5,
-    filters={"date": {"$gte": "2024-01-01"}},
+# Or via GraphRAG.search:
+response = rag.search(
+    query_text="What happened at Apple?",
+    retriever_config={"top_k": 10, "query_params": {"entity_name": "Apple"}},
 )
-# Supported operators: $eq $ne $lt $lte $gt $gte $between $in $like $ilike
 ```
 
 ---
 
-## Step 7 — VectorRetriever (return_properties)
+## Cypher 25 SEARCH Clause (v1.16.0, Neo4j 2026.x+)
 
 ```python
-from neo4j_graphrag.retrievers import VectorRetriever
-
+# Enable SEARCH clause syntax in vector/hybrid retrievers (requires Neo4j 2026+)
 retriever = VectorRetriever(
     driver=driver,
     index_name="chunk_embedding",
     embedder=embedder,
-    return_properties=["text", "source", "page_number"],  # subset of node props
+    use_search_clause=True,
 )
-# No retrieval_query needed — returns node properties directly
 ```
 
 ---
 
-## Step 8 — Text2CypherRetriever (no embedder)
+## ORDER BY on Cypher Retrievers (v1.16.0)
 
 ```python
-from neo4j_graphrag.retrievers import Text2CypherRetriever
-
-# LLM generates Cypher from natural language; no vector index needed
-retriever = Text2CypherRetriever(
-    driver=driver,
-    llm=OpenAILLM(model_name="gpt-4o"),
-    neo4j_schema=None,   # auto-fetched from db; or pass string
-    examples=["Q: Who works at Neo4j? A: MATCH (p:Person)-[:WORKS_AT]->(c:Company {name:'Neo4j'}) RETURN p.name"],
+results = retriever.search(
+    query_text="...",
+    top_k=10,
+    order_by="score DESC",
 )
-results = retriever.search(query_text="Which people work at Neo4j?")
 ```
 
 If `neo4j_schema=None`: retriever fetches schema automatically. For large schemas, pass a trimmed string to reduce LLM prompt size.
 
 **Destructive-query guard [v1.16+]**: `Text2CypherRetriever` runs `EXPLAIN` on the generated Cypher before execution and rejects queries that produce writes (`CREATE`, `MERGE`, `DELETE`, `SET`, `REMOVE`, etc.). LLM-generated writes are never executed against the graph.
 
+
 ---
 
-## Step 9 — Custom Prompt Template
+## Custom Prompt Template
 
 ```python
 from neo4j_graphrag.generation.prompts import RagTemplate
 
-custom_template = RagTemplate(
-    template="""Answer the question using ONLY the context below.
+template = RagTemplate(
+    template="""Answer using ONLY the context below.
 Context: {context}
 Question: {query_text}
 Answer:""",
     expected_inputs=["context", "query_text"],
 )
 
-rag = GraphRAG(retriever=retriever, llm=llm, prompt_template=custom_template)
+rag = GraphRAG(retriever=retriever, llm=llm, prompt_template=template)
+```
+
+---
+
+## return_context and response_fallback
+
+```python
+response = rag.search(
+    query_text="...",
+    retriever_config={"top_k": 5},
+    return_context=True,                        # include raw retrieved chunks
+    response_fallback="No relevant context.",   # skip LLM call if retriever returns nothing
+)
+print(response.answer)
+print(response.retriever_result)    # RawSearchResult when return_context=True
+```
+
+---
+
+## Message History (multi-turn)
+
+```python
+from neo4j_graphrag.message_history import InMemoryMessageHistory
+
+history = InMemoryMessageHistory()
+r1 = rag.search(query_text="Who is Alice?", message_history=history)
+r2 = rag.search(query_text="Where does she work?", message_history=history)
+```
+
+---
+
+## External Retrievers
+
+```python
+# --- Weaviate ---
+from neo4j_graphrag.retrievers import WeaviateNeo4jRetriever
+import weaviate
+
+weaviate_client = weaviate.connect_to_local()
+retriever = WeaviateNeo4jRetriever(
+    driver=driver,
+    client=weaviate_client,
+    collection="Chunk",
+    id_property_external="neo4j_id",
+    id_property_neo4j="id",
+    retrieval_query=retrieval_query,
+    node_label_neo4j="Chunk",       # optional: speeds up Neo4j lookup
+)
+
+# --- Pinecone ---
+from neo4j_graphrag.retrievers import PineconeNeo4jRetriever
+from pinecone import Pinecone
+
+pc = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+retriever = PineconeNeo4jRetriever(
+    driver=driver,
+    client=pc,
+    index_name="my-index",
+    id_property_neo4j="id",
+    retrieval_query=retrieval_query,
+)
+
+# --- Qdrant ---
+from neo4j_graphrag.retrievers import QdrantNeo4jRetriever
+from qdrant_client import QdrantClient
+
+retriever = QdrantNeo4jRetriever(
+    driver=driver,
+    client=QdrantClient(url="http://localhost:6333"),
+    collection_name="Chunk",
+    id_property_external="neo4j_id",
+    id_property_neo4j="id",
+    id_property_getter=lambda hit: hit.payload["neo4j_id"],  # custom ID extraction
+    retrieval_query=retrieval_query,
+)
+```
+
+---
+
+## LLM Providers
+
+All implement `LLMBase`. All support sync + async, tool calling, and automatic rate limiting.
+
+| Class | Extra | Notes |
+|---|---|---|
+| `OpenAILLM` | `openai` | Structured output; tool calling |
+| `AzureOpenAILLM` | `openai` | Azure-hosted OpenAI |
+| `AnthropicLLM` | `anthropic` | Tool calling |
+| `VertexAILLM` | `google` | Structured output; tool calling |
+| `MistralAILLM` | `mistralai` | Tool calling |
+| `CohereLLM` | `cohere` | |
+| `OllamaLLM` | `ollama` | Local; tool calling |
+| `BedrockLLM` | `bedrock` | Boto3 Converse API; added v1.15.0 |
+
+```python
+from neo4j_graphrag.llm import (
+    OpenAILLM, AzureOpenAILLM, AnthropicLLM, VertexAILLM,
+    MistralAILLM, CohereLLM, OllamaLLM, BedrockLLM,
+)
+
+llm = OpenAILLM(model_name="gpt-4.1", model_params={"temperature": 0})
+llm = AnthropicLLM(model_name="claude-3-5-sonnet-20241022")
+llm = VertexAILLM(model_name="gemini-2.0-flash")
+llm = OllamaLLM(model_name="llama3")           # no API key needed
+llm = BedrockLLM(model_id="anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+# Token usage tracking (v1.15.0+)
+response = llm.invoke("Hello")
+# response.usage → LLMUsage(request_tokens=N, response_tokens=M, total_tokens=T)
+
+# Graceful resource cleanup (v1.16.0+)
+llm.close()         # sync
+await llm.aclose()  # async
+```
+
+---
+
+## Embedder Providers
+
+All include automatic rate limiting with tenacity exponential backoff.
+
+| Class | Extra | Dims |
+|---|---|---|
+| `OpenAIEmbeddings` | `openai` | 3072 / 1536 |
+| `AzureOpenAIEmbeddings` | `openai` | varies |
+| `VertexAIEmbeddings` | `google` | 768 |
+| `MistralAIEmbeddings` | `mistralai` | 1024 |
+| `CohereEmbeddings` | `cohere` | 1024 |
+| `OllamaEmbeddings` | `ollama` | varies |
+| `SentenceTransformerEmbeddings` | `sentence-transformers` | 384+ |
+| `BedrockEmbeddings` | `bedrock` | varies; added v1.15.0 |
+
+```python
+from neo4j_graphrag.embeddings import (
+    OpenAIEmbeddings, VertexAIEmbeddings, CohereEmbeddings,
+    OllamaEmbeddings, SentenceTransformerEmbeddings, BedrockEmbeddings,
+)
+
+embedder = OpenAIEmbeddings(model="text-embedding-3-large")   # 3072 dims
+embedder = OpenAIEmbeddings(model="text-embedding-3-small")   # 1536 dims
+embedder = SentenceTransformerEmbeddings(model="all-MiniLM-L6-v2")  # 384 dims, local
+embedder = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0")
+```
+
+---
+
+## Index Setup
+
+```python
+from neo4j_graphrag.indexes import create_vector_index
+
+# Vector index — adjust dimensions to match your embedding model
+create_vector_index(
+    driver,
+    name="chunk_embedding",
+    label="Chunk",
+    embedding_property="embedding",
+    dimensions=1536,
+    similarity_fn="cosine",       # or "euclidean"
+)
+
+# Fulltext index (run as Cypher)
+# CREATE FULLTEXT INDEX chunk_fulltext IF NOT EXISTS
+#   FOR (c:Chunk) ON EACH [c.text]
+```
+
+---
+
+## Schema Inspection
+
+```python
+from neo4j_graphrag.schema import get_schema, get_structured_schema
+
+schema_str = get_schema(driver, sample=1000)           # human-readable string
+schema_dict = get_structured_schema(driver, sample=1000)  # dict with labels/rels/props
 ```
 
 ---
@@ -261,105 +521,35 @@ rag = GraphRAG(retriever=retriever, llm=llm, prompt_template=custom_template)
 
 | Error | Cause | Fix |
 |---|---|---|
-| `ModuleNotFoundError: neo4j_genai` | Old package installed | `pip uninstall neo4j-genai && pip install neo4j-graphrag` |
-| `retrieval_query` returns 0 rows | Missing `MATCH` or wrong rel direction | Add `EXPLAIN` prefix; verify node/rel names with `CALL db.schema.visualization()` |
-| `KeyError: 'score'` in results | `retrieval_query` missing `score` in RETURN | Add `score` to every `retrieval_query` RETURN clause |
-| `score` variable not found | Declared `score` as Cypher variable | Remove it — `score` is auto-injected; never re-declare |
-| `node` variable not found | Wrong variable name in retrieval_query | Use exactly `node` (lowercase); auto-injected by retriever |
-| Embedding dimension mismatch | Index created with different dims | Drop index, recreate with correct `vector.dimensions`, re-embed all chunks |
-| `IndexNotFoundError` | Index name typo or index not ONLINE | `SHOW INDEXES YIELD name, state` — verify name and state=ONLINE |
-| Low recall on hybrid search | Fulltext index not on right property | Fulltext index must cover same property as `node.text` in retrieval_query |
-| `perform_entity_resolution` slow | Large corpus with many entities | Set `perform_entity_resolution=False` for initial testing; enable in production |
-| `TypeError: coroutine` | Calling `pipeline.run_async()` without `await`/`asyncio.run()` | Wrap in `asyncio.run(pipeline.run_async(...))` |
-| Empty KG after pipeline run | `on_error="IGNORE"` masks extraction failures | Temporarily set `on_error="RAISE"` to see LLM extraction errors |
+| `ModuleNotFoundError: neo4j_genai` | Old package name | `pip uninstall neo4j-genai && pip install neo4j-graphrag` |
+| `retrieval_query` returns 0 rows | Missing `MATCH` or wrong rel direction | `EXPLAIN` the fragment; check `CALL db.schema.visualization()` |
+| `KeyError: 'score'` in results | `retrieval_query` RETURN missing `score` | Add `score` to every `retrieval_query` RETURN clause |
+| `score` variable not found | `score` re-declared in `retrieval_query` | Do **not** re-declare `score` — it is auto-injected |
+| `Text2CypherRetrievalError` | LLM generated a write statement | Expected security behavior (v1.16.0+); refine prompt or schema |
+| `TypeError: coroutine` | Missing `await` / `asyncio.run()` | Wrap async calls: `asyncio.run(pipeline.run_async(...))` |
+| Empty results from HybridRetriever | Fulltext index not ONLINE | `SHOW INDEXES YIELD name, state WHERE state <> 'ONLINE'` |
+| Embedding dimension mismatch | Index dims ≠ model dims | Recreate index with correct `dimensions=` value |
 
 ---
 
-## Embedder Quick Reference
+## Verification Checklist
 
-```python
-from neo4j_graphrag.embeddings import (
-    OpenAIEmbeddings,           # OpenAI text-embedding-3-*
-    AzureOpenAIEmbeddings,      # Azure-hosted OpenAI
-    VertexAIEmbeddings,         # Google Vertex AI
-    MistralAIEmbeddings,        # Mistral
-    CohereEmbeddings,           # Cohere embed-v3
-    OllamaEmbeddings,           # Local via Ollama
-    SentenceTransformerEmbeddings,  # Local HuggingFace
-)
-
-# Dimension mapping (must match vector index):
-# text-embedding-3-small → 1536
-# text-embedding-3-large → 3072
-# text-embedding-ada-002 → 1536
-# all-MiniLM-L6-v2       → 384
-```
-
-All embedders include automatic rate limiting with exponential backoff.
-
----
-
-## LLM Quick Reference
-
-```python
-from neo4j_graphrag.llm import (
-    OpenAILLM,
-    AzureOpenAILLM,
-    AnthropicLLM,
-    VertexAILLM,
-    MistralAILLM,
-    CohereLLM,
-    OllamaLLM,
-)
-# Any LangChain chat model also accepted by GraphRAG
-```
-
----
-
-## GraphRAG.search() Full Signature
-
-```python
-response = rag.search(
-    query_text="...",
-    retriever_config={
-        "top_k": 5,              # candidates per search (default 5)
-        "query_params": {...},   # passed to retrieval_query Cypher
-        "filters": {...},        # pre-filter before vector search
-    },
-    return_context=False,        # True: include retrieved chunks in response
-    response_fallback="No context found.",  # returned when retriever yields nothing
-)
-# response.answer → str
-# response.retriever_result → RawSearchResult (if return_context=True)
-```
-
----
-
-## Failure Recovery
-
-- 0 results from retrieval: run `retriever.search()` directly (skip LLM); check `top_k`, index name, embedding dims
-- LLM hallucinating: reduce `top_k`, improve `retrieval_query` to return more specific context
-- Slow queries: add `LIMIT` inside `retrieval_query` on expensive expansions; use `filters` to pre-reduce candidates
-- Embedding dimension mismatch: `SHOW INDEXES YIELD name, options` — check `vector.dimensions`
+- [ ] `neo4j-graphrag` (not `neo4j-genai`) installed; `neo4j >= 5.17.0` driver
+- [ ] Vector index ONLINE before ingesting embeddings or running retriever
+- [ ] Fulltext index ONLINE if using Hybrid variants
+- [ ] Embedding dims in `create_vector_index` match the embedder output
+- [ ] `retrieval_query` returns `node` and `score` in RETURN (not re-declared)
+- [ ] `query_params` passed via `retriever_config` on `rag.search()` (not on retriever constructor)
+- [ ] API keys in env vars; never hardcoded
+- [ ] `llm.close()` called when done to release resources
 
 ---
 
 ## References
 
-- [references/retrievers.md](references/retrievers.md) — full retriever API, all constructor params, result_formatter, ToolsRetriever, external DB retrievers
-- [GraphRAG Python Docs](https://neo4j.com/docs/neo4j-graphrag-python/current/)
-- [neo4j-graphrag GitHub](https://github.com/neo4j/neo4j-graphrag-python)
-
----
-
-## Checklist
-
-- [ ] `neo4j-genai` uninstalled; `neo4j-graphrag` installed; import paths updated
-- [ ] Vector index ONLINE before ingesting or querying
-- [ ] Fulltext index ONLINE if using Hybrid retriever
-- [ ] Embedding dims match `vector.dimensions` in index config
-- [ ] `retrieval_query` includes `node` and `score` in RETURN clause (both required)
-- [ ] `node` and `score` NOT re-declared in `retrieval_query` — auto-injected
-- [ ] `query_params` passed via `retriever_config` or direct `retriever.search()` arg
-- [ ] `retriever_config={"top_k": N}` set on `rag.search()` (default 5)
-- [ ] Credentials in env vars; never hardcoded
+Load on demand:
+- [neo4j-graphrag package docs](https://neo4j.com/docs/neo4j-graphrag-python/current/)
+- [RAG & GraphRAG user guide](https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_rag.html)
+- [KG Builder user guide](https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_kg_builder.html)
+- [GitHub — neo4j-graphrag-python](https://github.com/neo4j/neo4j-graphrag-python)
+- [Examples folder](https://github.com/neo4j/neo4j-graphrag-python/tree/main/examples)


### PR DESCRIPTION
## Summary

- **neo4j-graphrag-skill**: Full rewrite to cover v1.16.0 features — `ToolsRetriever`, `BedrockLLM`/`BedrockEmbeddings`, `Text2CypherRetriever` EXPLAIN security guard, Cypher 25 `SEARCH` clause, `ORDER BY` on Cypher retrievers, `LLMUsage` token tracking, `close()`/`aclose()`, updated model names to `gpt-4.1`, complete LLM and embedder provider tables
- **neo4j-document-import-skill**: Updated `SchemaBuilder` → `GraphSchema` + `ConstraintType` API (v1.8.0+), `from_pdf` → `from_file` / `MarkdownLoader` (v1.15.0+), Amazon Bedrock extra, `ParquetWriter` and `SchemaFromTextExtractor` sections, structured output auto-management note, new error rows for v1.14/v1.15 gotchas

## Test plan

- [ ] Verify all code snippets import from correct module paths (`neo4j_graphrag.*`)
- [ ] Confirm `GraphSchema` + `ConstraintType` examples match the v1.15.0+ API
- [ ] Check `from_file=True` / `from_pdf` deprecation wording is accurate
- [ ] Confirm `gpt-4.1` and `gpt-4.1-mini` are the current recommended model names

🤖 Generated with [Claude Code](https://claude.ai/claude-code)