### PR TITLE
enhance(neo4j-modeling-skill): add interactive visual schema modeling

### DIFF
--- a/neo4j-modeling-skill/README.md
+++ b/neo4j-modeling-skill/README.md
@@ -1,10 +1,26 @@
-> **Status: Draft / WIP**
-
 # neo4j-modeling-skill
 
-Guides agents through designing and reviewing Neo4j graph data models: node labels, relationship types, properties, constraints, and anti-pattern detection.
+Guides agents through designing, reviewing, and visually modeling Neo4j graph data models — from theoretical best practices to interactive schema diagrams.
 
-**Install:**
+## Capabilities
+
+### Theoretical Modeling Guidance
+- Decision tables: node vs relationship vs property vs label
+- Anti-pattern detection and fixes
+- Naming conventions and schema standards
+- Supernode detection and mitigation strategies
+- Relational → graph migration patterns
+- Intermediate node patterns for n-ary relationships
+
+### Interactive Visual Schema Design
+- Generate interactive React artifacts for visual schema editing
+- 32 pre-built reference models across 6 industries
+- arrows.app JSON round-trip compatibility
+- Export to Cypher `CREATE` statements
+- SVG static rendering for CLI/API environments
+
+## Install
+
 ```bash
 npx skills add https://github.com/neo4j-contrib/neo4j-skills --skill neo4j-modeling-skill
 ```

--- a/neo4j-modeling-skill/SKILL.md
+++ b/neo4j-modeling-skill/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: neo4j-modeling-skill
-description: Design, review, and refactor Neo4j graph data models. Use when choosing node
-  labels vs relationship types vs properties, migrating relational/document schemas to
-  graph, detecting anti-patterns (generic labels, supernodes, missing constraints),
-  designing intermediate nodes for n-ary relationships, enforcing schema with constraints
-  and indexes, or assessing an existing model against graph modeling best practices.
-  Does NOT handle Cypher query authoring — use neo4j-cypher-skill.
-  Does NOT handle Spring Data Neo4j entity mapping — use neo4j-spring-data-skill.
-  Does NOT handle GraphQL type definitions — use neo4j-graphql-skill.
-  Does NOT handle data import — use neo4j-import-skill.
-version: 1.0.0
+description: Design, review, refactor, and visually model Neo4j property graph schemas. Use when choosing node labels vs relationship types vs properties, migrating relational or document schemas to graph, detecting anti-patterns (generic labels, supernodes, missing constraints), designing intermediate nodes for n-ary relationships, enforcing schema with constraints and indexes, assessing an existing model, or creating interactive visual schema diagrams. Also triggers for "design a graph schema", "visualise", "arrows.app", "reference model", "interactive schema editor", or any Neo4j use case. Does NOT handle Cypher query authoring — use neo4j-cypher-skill. Does NOT handle Spring Data Neo4j entity mapping — use neo4j-spring-data-skill. Does NOT handle GraphQL type definitions — use neo4j-graphql-skill. Does NOT handle data import — use neo4j-import-skill. Does NOT trigger for graph charts (bar/line/pie), mathematical graphs, or visualising query results.
+version: 1.1.0
 allowed-tools: WebFetch Bash
 ---
 
@@ -22,6 +14,8 @@ allowed-tools: WebFetch Bash
 - Designing intermediate nodes for n-ary or complex relationships
 - Detecting and mitigating supernode / high-fanout problems
 - Choosing and creating constraints + indexes for a model
+- Creating interactive visual schema diagrams
+- Loading from 32 pre-built reference models or user-uploaded arrows.app JSON
 
 ## When NOT to Use
 
@@ -29,6 +23,7 @@ allowed-tools: WebFetch Bash
 - **Spring Data Neo4j (@Node, @Relationship)** → `neo4j-spring-data-skill`
 - **GraphQL type definitions** → `neo4j-graphql-skill`
 - **Importing data (LOAD CSV, APOC import)** → `neo4j-import-skill`
+- **Graph charts (bar/line/pie), mathematical graphs, query result visualisation** — out of scope
 
 ---
 
@@ -63,13 +58,13 @@ MCP tool map:
 2. Nodes = entities (nouns) with identity; rels = connections (verbs) with direction
 3. Labels PascalCase; rel types SCREAMING_SNAKE_CASE; properties camelCase
 4. Every node type used in MERGE has a uniqueness constraint on its key property
-5. Add property type constraints (`REQUIRE n.prop IS :: STRING`) where the type is known — helps the query planner and catches bad writes early
+5. Add property type constraints (`REQUIRE n.prop IS :: STRING`) where type is known
 6. No generic labels (`:Entity`, `:Node`, `:Thing`); no generic rel types (`:RELATED_TO`, `:HAS`)
-7. Security labels (used for row-level access control) should start with a common prefix (e.g. `Sec`) so application code can reliably filter them out of the domain schema
+7. Security labels (row-level access control) start with common prefix (e.g. `Sec`)
 8. Rel direction encodes semantic meaning — not arbitrary
 9. Inspect schema before proposing any change on an existing database
-10. All constraint/index DDL uses `IF NOT EXISTS` — safe to rerun
-11. **On Neo4j 2026.02+ (Enterprise/Aura):** consider `ALTER CURRENT GRAPH TYPE SET { … }` or `EXTEND GRAPH TYPE WITH { … }` to declare the full model in one block instead of individual `CREATE CONSTRAINT` statements — see `neo4j-cypher-skill/references/graph-type.md`. **PREVIEW** — syntax may change before GA.
+10. All constraint/index DDL uses `IF NOT EXISTS`
+11. **On Neo4j 2026.02+ (Enterprise/Aura):** consider `ALTER CURRENT GRAPH TYPE SET { … }` — see `neo4j-cypher-skill/references/graph-type.md`. PREVIEW — syntax may change before GA.
 
 ---
 
@@ -80,7 +75,7 @@ MCP tool map:
 | Question | Answer | Model as |
 |---|---|---|
 | Is it a thing with identity, queried as entry point? | Yes | Node |
-| Is it a connection between two things with direction? | Yes | Relationship |
+| Is a connection between two things with direction? | Yes | Relationship |
 | Does the connection have its own properties or multiple targets? | Yes | Intermediate node |
 | Is it a scalar always returned with its parent, never filtered alone? | Yes | Property on parent |
 | Is it a category used for type-based filtering or path traversal? | Yes | Label (not a property) |
@@ -97,8 +92,6 @@ MCP tool map:
 | Example: `:Active`, `:Verified`, `:Premium` | Example: `status`, `score`, `email` |
 
 Rule: adding a label is cheap; scanning all `:Label` nodes is fast. Never model high-cardinality values as labels.
-
----
 
 ### Intermediate Node Pattern
 
@@ -118,7 +111,6 @@ Use when a relationship needs its own properties, connects >2 entities, or is in
 
 **Employment overlap example:**
 ```cypher
-// Find colleagues who overlapped at same company
 MATCH (p1:Person)-[:WORKED_AT]->(e1:Employment)-[:AT]->(c:Company)<-[:AT]-(e2:Employment)<-[:WORKED_AT]-(p2:Person)
 WHERE p1 <> p2
   AND e1.startDate <= e2.endDate AND e2.startDate <= e1.endDate
@@ -146,7 +138,7 @@ Promote relationship to intermediate node when:
 | NULL FK (optional relation) | Absent relationship | No node created; absence is the signal |
 | Polymorphic FK (Rails-style) | Multiple labels or relationship types | Split into type-specific rels |
 | Self-referential FK | Same-label relationship | `:Employee {managerId}` → `(e)-[:REPORTS_TO]->(m)` |
-| Audit/history columns | Intermediate versioning node | See References for versioning pattern |
+| Audit/history columns | Intermediate versioning node | See references/modeling-patterns.md |
 
 ---
 
@@ -154,17 +146,12 @@ Promote relationship to intermediate node when:
 
 **Detect:**
 ```cypher
-// Find top-10 highest-degree nodes
 MATCH (n)
 RETURN labels(n) AS labels, elementId(n) AS id, count{ (n)--() } AS degree
-ORDER BY degree DESC LIMIT 10
+ORDER BY degree DESC LIMIT 10;
 ```
 
-Node with degree >> median for its label = supernode candidate. Any node with >100K relationships will degrade traversal queries that pass through it.
-
-**Causes:**
-- Domain supernodes: airports, celebrities, popular hashtags — unavoidable
-- Modeling supernodes: gender, country, status modeled as nodes with millions of edges — avoidable
+Node with degree >> median for its label = supernode candidate. Any node with >100K relationships degrades traversal queries that pass through it.
 
 **Mitigation strategies (in priority order):**
 
@@ -173,20 +160,9 @@ Node with degree >> median for its label = supernode candidate. Any node with >1
 | **Query direction** | Directional asymmetry exists | Query from low-degree side; exploit direction |
 | **Relationship type split** | Supernode serves multiple roles | `:FOLLOWS` + `:FAN` instead of single `:RELATED_TO` |
 | **Label segregation** | Supernode conflates entity types | `:Celebrity` vs `:User` → query only relevant subtype |
-| **Bucket pattern** | Time-series or high-volume event nodes | See below |
+| **Bucket pattern** | Time-series or high-volume event nodes | See references/modeling-patterns.md |
 | **Avoid modeling** | Low-cardinality categoricals | Use label instead of node (`:Active` not `(:Status {name:"Active"})`) |
 | **Join hint** | Query tuning last resort | `USING JOIN ON n` in Cypher |
-
-**Bucket pattern (time-series / high-volume):**
-```cypher
-// Instead of: (:User)-[:VIEWED]->(:Page) (millions of rels per user)
-// Bucket by hour:
-(u:User)-[:VIEWED_IN]->(b:ViewBucket {userId: u.id, hour: '2025-04-28T14'})-[:VIEWED]->(p:Page)
-
-// Query last hour's views without traversing full history:
-MATCH (u:User {id: $uid})-[:VIEWED_IN]->(b:ViewBucket {hour: $hour})-[:VIEWED]->(p)
-RETURN p.url
-```
 
 ---
 
@@ -202,70 +178,6 @@ RETURN p.url
 
 ---
 
-### Schema Enforcement — What to Create for Each Element
-
-Run all DDL with `IF NOT EXISTS`. Apply before importing data.
-
-```cypher
-// 1. Uniqueness constraint — every node type used in MERGE
-CREATE CONSTRAINT person_id_unique IF NOT EXISTS
-  FOR (p:Person) REQUIRE p.id IS UNIQUE;
-
-// 2. Existence constraint (Enterprise) — mandatory properties
-CREATE CONSTRAINT person_name_exists IF NOT EXISTS
-  FOR (p:Person) REQUIRE p.name IS NOT NULL;
-
-// 3. Property type constraint (Enterprise) — enforce data type
-CREATE CONSTRAINT person_born_integer IF NOT EXISTS
-  FOR (p:Person) REQUIRE p.born IS :: INTEGER;
-
-// 4. Key constraint (Enterprise) — unique + exists in one
-CREATE CONSTRAINT movie_tmdbid_key IF NOT EXISTS
-  FOR (m:Movie) REQUIRE m.tmdbId IS NODE KEY;
-
-// 5. Range index — equality and range filters on properties
-CREATE INDEX person_name_idx IF NOT EXISTS
-  FOR (p:Person) ON (p.name);
-
-// 6. Fulltext index — CONTAINS, STARTS WITH, free text search
-CREATE FULLTEXT INDEX person_fulltext IF NOT EXISTS
-  FOR (n:Person) ON EACH [n.name, n.bio];
-
-// 7. Vector index — embedding similarity search
-CREATE VECTOR INDEX chunk_embedding_idx IF NOT EXISTS
-  FOR (c:Chunk) ON (c.embedding)
-  OPTIONS { indexConfig: { `vector.dimensions`: 1536, `vector.similarity_function`: 'cosine' } };
-
-// 8. Relationship index — filter on rel properties
-CREATE INDEX acted_in_year_idx IF NOT EXISTS
-  FOR ()-[r:ACTED_IN]-() ON (r.year);
-```
-
-After creating indexes, poll until ONLINE:
-```cypher
-SHOW INDEXES YIELD name, state WHERE state <> 'ONLINE' RETURN name, state;
-```
-Do NOT use an index until state = `ONLINE`.
-
----
-
-### Vector / Embedding Property Modeling
-
-Store embeddings on dedicated `:Chunk` nodes, never on business nodes:
-
-```
-(:Document)-[:HAS_CHUNK]->(c:Chunk {text: "...", embedding: [...]})
-```
-
-Rules:
-- Chunk node: `text` (source text), `embedding` (float array), `chunkIndex` (int)
-- Parent document: metadata only (title, url, createdAt)
-- Vector index on `c.embedding` only
-- Chunk size 200–500 tokens with 20% overlap is production default [field]
-- Do NOT put embedding on `:Document` — makes the node too large and pollutes traversal
-
----
-
 ### Anti-Patterns Table
 
 | Anti-pattern | Problem | Fix |
@@ -278,8 +190,155 @@ Rules:
 | MERGE without uniqueness constraint | Duplicate nodes silently created | Add constraint before any MERGE |
 | Missing relationship direction meaning | Arbitrary direction; confusing model | Direction = semantic flow of action |
 | Junction table modeled as bare property | Loses history and extensibility | Intermediate node with its own properties |
-| `id` as property name | `id(n)` is a deprecated Cypher function (use `elementId(n)`); bare `id` is fine as a property name in practice, but domain-qualified names (`personId`, `movieId`) are clearer and avoid any future ambiguity | Prefer `personId`, `movieId`, `tmdbId` where it aids readability |
+| `id` as property name | `id(n)` is deprecated (use `elementId(n)`); bare `id` is fine but domain-qualified names (`personId`, `movieId`) are clearer | Prefer `personId`, `movieId`, `tmdbId` |
 | All dates as strings | No range queries; no temporal operators | Use Neo4j `date()` or `datetime()` type |
+
+---
+
+## Schema Enforcement
+
+See [references/schema-enforcement.md](references/schema-enforcement.md) for full constraint/index DDL examples, vector index setup, and embedding property modeling rules.
+
+---
+
+## Visual Modeling
+
+When the user wants to create, visualise, or edit a graph schema interactively, run the injector script to produce an interactive React artifact.
+
+### The Injector Script
+
+`scripts/inject.py` lives in this skill's folder. Resolve the absolute path from where this SKILL.md was loaded — do NOT hardcode `/mnt/skills/...`:
+
+```bash
+SCRIPT=$(find /mnt /opt ~/.claude /skills /workspace 2>/dev/null \
+  -name inject.py -path '*/neo4j-modeling-skill/*' | head -1)
+python3 "$SCRIPT" <input> [output.jsx]
+```
+
+The script auto-detects `<input>`:
+
+| Input type | Example |
+|---|---|
+| Reference model ID | `inject.py claims-fraud` |
+| File path | `inject.py /path/to/schema.json` |
+| Stdin | `cat schema.json | inject.py` |
+| List catalog | `inject.py --list` |
+
+Accepted wrapping formats (auto-unwrapped): bare `{nodes, relationships}`, arrows.app `{graph: {...}}`, reference model `{initialGraph: {...}}`.
+
+Default output: `/mnt/user-data/outputs/graph-schema-editor.jsx` when that directory exists; otherwise the current working directory. Pass a `.jsx` path as the second argument to override.
+
+### Outputs
+
+Each injection writes **three sibling files** with matching basename:
+
+- **`.jsx`** — interactive React editor (renders in claude.ai artifacts)
+- **`.json`** — arrows.app-compatible schema (paste into https://arrows.app)
+- **`.svg`** — static dark-theme rendering for non-artifact environments
+
+### Minimal Schema Shape
+
+Each **node** needs only `caption`. Supply `properties` when you have them. Everything else is auto-filled.
+
+| Field | Required? | Default when omitted |
+|---|---|---|
+| `caption` | yes | — |
+| `properties` | no | `{}` |
+| `id` | no | `n0`, `n1`, … |
+| `position` | no | Circular auto-layout centred on viewport |
+| `labels` | no | `[caption]` |
+| `style.color` | no | Cycled through 10-colour palette |
+| `style.radius` | no | `55` |
+
+Each **relationship** needs `type`, and either `from`/`to` (caption lookup) or `fromId`/`toId` (explicit ids — required when two nodes share a caption).
+
+| Field | Required? | Notes |
+|---|---|---|
+| `type` | yes | UPPER_SNAKE_CASE, e.g. `ACTED_IN` |
+| `from` or `fromId` | yes | Caption lookup OR explicit id |
+| `to` or `toId` | yes | Caption lookup OR explicit id |
+| `properties` | no | `{}` |
+| `id` | no | `r0`, `r1`, … |
+
+### Custom Domain — Stdin Pattern
+
+```bash
+cat <<'EOF' | python3 inject.py
+{
+  "nodes": [
+    { "caption": "Customer", "properties": { "customerId": "string", "name": "string" } },
+    { "caption": "Order",    "properties": { "orderId": "string", "total": "float" } },
+    { "caption": "Product",  "properties": { "sku": "string", "price": "float" } }
+  ],
+  "relationships": [
+    { "type": "PLACED",   "from": "Customer", "to": "Order" },
+    { "type": "CONTAINS", "from": "Order",    "to": "Product", "properties": { "quantity": "integer" } }
+  ]
+}
+EOF
+```
+
+### Multi-Label Nodes
+
+Neo4j supports multiple labels per node. Supply a `labels` array with more than one entry:
+
+```json
+{
+  "nodes": [
+    { "caption": "Account", "labels": ["Account", "Internal"], "properties": { "accountNumber": "string" } },
+    { "caption": "Account", "labels": ["Account", "External"], "properties": { "accountNumber": "string" } }
+  ],
+  "relationships": [
+    { "type": "TRANSFERRED_TO", "fromId": "n0", "toId": "n1" }
+  ]
+}
+```
+
+Invariants: `caption` is always the first element of `labels`; duplicates and empties are dropped. Relationship endpoints cannot resolve by caption when two nodes share one — use explicit `fromId`/`toId`.
+
+### Reference Models
+
+32 pre-built models across Financial Services, Insurance, Healthcare & Life Sciences, Manufacturing, Cybersecurity, and Industry Agnostic. Run `inject.py --list` for the live catalog. See [references/reference-models.md](references/reference-models.md) for the full catalog with keyword mapping.
+
+When a reference model is injected, the script surfaces its name and source URL — share these with the user.
+
+### Presenting Results
+
+**In claude.ai (artifacts render):** Call `present_files` on the `.jsx` first. Mention `.json` and `.svg` as companion files. Brief orientation:
+
+- Double-click canvas (or "Add Node") to add nodes
+- Drag from a node's edge to another node to create a relationship
+- Click any element to edit in sidebar — primary label, additional labels, properties, colour, radius
+- Scroll wheel zooms; drag canvas to pan
+- Export → "Copy JSON" gives arrows.app-compatible JSON
+
+**In CLI / API (no artifact rendering):** Lead with `.svg` for visual preview, `.json` as portable artifact. User can paste JSON into https://arrows.app for visual editing, then export back and re-feed to the injector.
+
+### Editing in arrows.app
+
+The exported `.json` is byte-compatible with https://arrows.app:
+
+1. Open https://arrows.app and click *Use Storage > Local*
+2. Paste contents of `.json`
+3. Edit visually with arrows.app's full toolset
+4. Use *Export* → *JSON* to get updated schema
+5. Paste JSON back in chat — injector handles both formats interchangeably
+
+### Saving User Edits
+
+The `.jsx` artifact runs in a sandbox — it cannot write to disk. Round-trip:
+
+1. User clicks **Export → Copy JSON** in the editor
+2. User pastes it in chat ("here's my updated schema" or "save my changes")
+3. **Re-run the injector against the pasted JSON:**
+
+```bash
+cat <<'EOF' | python3 inject.py
+{ "style": {...}, "nodes": [...], "relationships": [...] }
+EOF
+```
+
+This refreshes `.jsx`, `.json`, and `.svg` so all three stay in sync.
 
 ---
 
@@ -348,13 +407,17 @@ Severity semantics:
 - [ ] Indexes polled to ONLINE before use
 - [ ] Assessment output follows the structured format above
 - [ ] Every prohibition paired with a concrete fix
+- [ ] Visual artifact presented when user wants to see/edit schema interactively
+- [ ] Reference model source URL shared when loading a pre-built model
 
 ---
 
 ## References
 
 Load on demand:
+- [references/schema-enforcement.md](references/schema-enforcement.md) — constraint/index DDL, vector/embedding modeling
 - [references/modeling-patterns.md](references/modeling-patterns.md) — time-series, versioning, multi-tenancy, linked list, access control patterns
+- [references/reference-models.md](references/reference-models.md) — full catalog of 32 pre-built industry reference models
 - [Neo4j Data Modeling Guide](https://neo4j.com/docs/getting-started/data-modeling/guide-data-modeling/)
 - [Neo4j Modeling Tips](https://neo4j.com/docs/getting-started/data-modeling/modeling-tips/)
 - [GraphAcademy: Graph Data Modeling Fundamentals](https://graphacademy.neo4j.com/courses/modeling-fundamentals/)

--- a/neo4j-modeling-skill/assets/graph-editor-template.jsx
+++ b/neo4j-modeling-skill/assets/graph-editor-template.jsx
@@ -1,0 +1,900 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+const COLORS = [
+  "#4C8BF5", "#E5484D", "#30A46C", "#E38627", "#8B5CF6",
+  "#06B6D4", "#EC4899", "#F59E0B", "#6366F1", "#14B8A6",
+];
+
+const initialGraph = {
+  nodes: [
+    { id: "n0", position: { x: 300, y: 250 }, caption: "Person", labels: ["Person"], properties: { name: "string", age: "integer" }, style: { color: COLORS[0], radius: 50 } },
+    { id: "n1", position: { x: 600, y: 250 }, caption: "Movie", labels: ["Movie"], properties: { title: "string", released: "integer" }, style: { color: COLORS[1], radius: 50 } },
+  ],
+  relationships: [
+    { id: "r0", type: "ACTED_IN", fromId: "n0", toId: "n1", properties: { role: "string" } },
+  ],
+  style: {},
+};
+
+function uid() { return "n" + Math.random().toString(36).slice(2, 8); }
+function rid() { return "r" + Math.random().toString(36).slice(2, 8); }
+function vec(a, b) { return { x: b.x - a.x, y: b.y - a.y }; }
+function len(v) { return Math.sqrt(v.x * v.x + v.y * v.y); }
+function norm(v) { const l = len(v) || 1; return { x: v.x / l, y: v.y / l }; }
+
+function getEdgePoints(from, to, fromR, toR) {
+  const d = vec(from, to);
+  const n = norm(d);
+  return { x1: from.x + n.x * fromR, y1: from.y + n.y * fromR, x2: to.x - n.x * toR, y2: to.y - n.y * toR };
+}
+
+// Self-loop that fans out by index so multiple self-rels don't overlap.
+// The loop is guaranteed to sit OUTSIDE the node: each control point starts
+// on the node boundary and is pushed outward along the centerAngle direction
+// (plus a small perpendicular component to give the loop width), so the
+// Bezier curve bulges away from the node and never re-enters it.
+function getSelfLoopPath(cx, cy, r, index = 0, total = 1) {
+  const baseAngle = -Math.PI / 2; // top of node
+  const spread = Math.PI * 0.55; // fan between loops when there are multiple
+  const fanOffset = total > 1 ? (index - (total - 1) / 2) * spread : 0;
+  const centerAngle = baseAngle + fanOffset;
+
+  // Opening on the node where the loop starts and ends
+  const halfArc = Math.PI * 0.16;
+  const startAngle = centerAngle - halfArc;
+  const endAngle = centerAngle + halfArc;
+
+  // How far the loop bulges outward from the node surface. Grows per sibling
+  // so stacked loops remain visually distinguishable.
+  const reach = r * 1.7 + index * 18;
+
+  const sx = cx + r * Math.cos(startAngle);
+  const sy = cy + r * Math.sin(startAngle);
+  const ex = cx + r * Math.cos(endAngle);
+  const ey = cy + r * Math.sin(endAngle);
+
+  // Unit vectors: radial = direction the loop bulges; tangent = perpendicular
+  // spreading for the teardrop shape.
+  const rad = { x: Math.cos(centerAngle), y: Math.sin(centerAngle) };
+  const tan = { x: -rad.y, y: rad.x };
+  const sideSpread = r * 0.9;
+
+  // Control points are offset from each endpoint in the OUTWARD radial
+  // direction (never inward toward the node). A tangential component spreads
+  // the two controls apart so the curve forms a loop rather than a spike.
+  const cpx1 = sx + rad.x * reach - tan.x * sideSpread;
+  const cpy1 = sy + rad.y * reach - tan.y * sideSpread;
+  const cpx2 = ex + rad.x * reach + tan.x * sideSpread;
+  const cpy2 = ey + rad.y * reach + tan.y * sideSpread;
+
+  // Label sits at the outer apex of the loop (t = 0.5 on the Bezier).
+  // For a symmetric cubic, the midpoint is at the average of the four points,
+  // biased by the Bernstein weights (1, 3, 3, 1) / 8 = (1/8, 3/8, 3/8, 1/8).
+  const midX = (sx + 3 * cpx1 + 3 * cpx2 + ex) / 8;
+  const midY = (sy + 3 * cpy1 + 3 * cpy2 + ey) / 8;
+
+  return { path: `M ${sx} ${sy} C ${cpx1} ${cpy1}, ${cpx2} ${cpy2}, ${ex} ${ey}`, midX, midY };
+}
+
+// Export helpers
+// Default style block emitted on export. arrows.app preserves these on
+// import, so paste-into-arrows.app produces a sensible starting look. Kept
+// in sync with inject.py's ARROWS_DEFAULT_STYLE — change them together.
+const ARROWS_DEFAULT_STYLE = {
+  "font-family": "sans-serif",
+  "background-color": "#ffffff",
+  "background-image": "",
+  "background-size": "100%",
+  "node-color": "#ffffff",
+  "border-width": 4,
+  "border-color": "#000000",
+  "radius": 50,
+  "node-padding": 5,
+  "node-margin": 2,
+  "outside-position": "auto",
+  "node-icon-image": "",
+  "node-background-image": "",
+  "icon-position": "inside",
+  "icon-size": 64,
+  "caption-position": "inside",
+  "caption-max-width": 200,
+  "caption-color": "#000000",
+  "caption-font-size": 50,
+  "caption-font-weight": "normal",
+  "label-position": "inside",
+  "label-display": "pill",
+  "label-color": "#000000",
+  "label-background-color": "#ffffff",
+  "label-border-color": "#000000",
+  "label-border-width": 4,
+  "label-font-size": 40,
+  "label-padding": 5,
+  "label-margin": 4,
+  "directionality": "directed",
+  "detail-position": "inline",
+  "detail-orientation": "parallel",
+  "arrow-width": 5,
+  "arrow-color": "#000000",
+  "margin-start": 5,
+  "margin-end": 5,
+  "margin-peer": 20,
+  "attachment-start": "normal",
+  "attachment-end": "normal",
+  "relationship-icon-image": "",
+  "type-color": "#000000",
+  "type-background-color": "#ffffff",
+  "type-border-color": "#000000",
+  "type-border-width": 0,
+  "type-font-size": 16,
+  "type-padding": 5,
+  "property-position": "outside",
+  "property-alignment": "colon",
+  "property-color": "#000000",
+  "property-font-size": 16,
+  "property-font-weight": "normal",
+};
+
+function toArrowsJSON(graph) {
+  // Match arrows.app's native export shape: flat (no `graph` wrapper),
+  // kebab-case style keys, and caption="" when it equals labels[0] (the
+  // common case — arrows.app uses labels[0] as the display text). We emit
+  // an explicit caption only when it diverges from labels[0], preserving
+  // any deliberate user choice.
+  return JSON.stringify({
+    style: { ...ARROWS_DEFAULT_STYLE },
+    nodes: graph.nodes.map(n => {
+      const labels = n.labels || [];
+      const primary = labels[0] || "";
+      const caption = n.caption === primary ? "" : (n.caption || "");
+      return {
+        id: n.id,
+        position: n.position,
+        caption,
+        style: {
+          "node-color": n.style?.color || "#4C8BF5",
+          "radius": n.style?.radius || 50,
+        },
+        labels: [...labels],
+        properties: { ...(n.properties || {}) },
+      };
+    }),
+    relationships: graph.relationships.map(r => ({
+      id: r.id,
+      type: r.type,
+      style: {},
+      properties: { ...(r.properties || {}) },
+      fromId: r.fromId,
+      toId: r.toId,
+    })),
+  }, null, 2);
+}
+
+function toCypher(graph) {
+  const lines = [];
+  graph.nodes.forEach(n => {
+    const labels = n.labels.length ? ":" + n.labels.join(":") : "";
+    const props = Object.entries(n.properties || {}).map(([k, v]) => `${k}: '${v}'`).join(", ");
+    lines.push(`CREATE (${n.id}${labels} {${props}})`);
+  });
+  graph.relationships.forEach(r => {
+    const props = Object.entries(r.properties || {}).map(([k, v]) => `${k}: '${v}'`).join(", ");
+    const propStr = props ? ` {${props}}` : "";
+    lines.push(`CREATE (${r.fromId})-[:${r.type}${propStr}]->(${r.toId})`);
+  });
+  return lines.join("\n");
+}
+
+// --- Sub-components ---
+const labelStyle = { fontWeight: 600, fontSize: 11, textTransform: "uppercase", letterSpacing: 1, color: "#94a3b8", display: "block", marginBottom: 2 };
+const monoInputStyle = { flex: 1, background: "#1e293b", border: "1px solid #334155", color: "#e2e8f0", borderRadius: 4, padding: "4px 6px", fontSize: 12, fontFamily: "'JetBrains Mono', monospace" };
+const fieldInputStyle = { width: "100%", marginTop: 4, marginBottom: 10, background: "#1e293b", border: "1px solid #334155", color: "#e2e8f0", borderRadius: 4, padding: "6px 8px", fontSize: 13, boxSizing: "border-box" };
+const smallBtnStyle = { background: "none", border: "1px solid #334155", color: "#94a3b8", borderRadius: 4, cursor: "pointer", fontSize: 11, padding: "2px 8px" };
+
+function PropertyEditor({ properties, onChange }) {
+  const entries = Object.entries(properties || {});
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
+        <span style={labelStyle}>Properties</span>
+        <button onClick={() => onChange({ ...properties, "": "" })} style={smallBtnStyle}>+ Add</button>
+      </div>
+      {entries.map(([k, v], i) => (
+        <div key={i} style={{ display: "flex", gap: 4, marginBottom: 4, alignItems: "center" }}>
+          <input value={k} onChange={e => {
+            const copy = {};
+            Object.entries(properties).forEach(([ok, ov]) => { copy[ok === k ? e.target.value : ok] = ov; });
+            onChange(copy);
+          }} placeholder="key" style={monoInputStyle} />
+          <span style={{ color: "#475569" }}>:</span>
+          <input value={v} onChange={e => onChange({ ...properties, [k]: e.target.value })} placeholder="type" style={monoInputStyle} />
+          <button onClick={() => { const c = { ...properties }; delete c[k]; onChange(c); }} style={{ background: "none", border: "none", color: "#64748b", cursor: "pointer", fontSize: 14, padding: 0, lineHeight: 1 }}>×</button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Parse a comma-separated string into a clean extras array (trim, drop empties,
+// drop the primary caption if it's been typed again, dedup). Used by
+// AdditionalLabelsInput and also wherever we need the same semantics.
+function parseExtraLabels(text, caption) {
+  const seen = new Set();
+  const out = [];
+  for (const raw of text.split(",")) {
+    const lab = raw.trim();
+    if (!lab || lab === caption || seen.has(lab)) continue;
+    seen.add(lab);
+    out.push(lab);
+  }
+  return out;
+}
+
+// The separator-disappears bug this fixes: if the input's displayed value is
+// derived from the parsed labels array every render, then a trailing comma or
+// space gets normalised away between keystrokes, the input shortens, and the
+// cursor lands in the wrong place — making it impossible to actually type a
+// separator. The fix: keep the input's displayed text as local state, and only
+// propagate the parsed array upward. When the user selects a different node,
+// reset the local text from the new node's labels.
+function AdditionalLabelsInput({ nodeId, extras, caption, onChange }) {
+  const [text, setText] = useState(extras.join(", "));
+
+  // Reset the text when the user selects a different node. We key on nodeId
+  // (stable for the life of the node) rather than on `extras` (which changes
+  // as the user types), so typing doesn't fight itself.
+  useEffect(() => {
+    setText(extras.join(", "));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId]);
+
+  return (
+    <input
+      value={text}
+      onChange={e => {
+        const next = e.target.value;
+        setText(next);
+        onChange(parseExtraLabels(next, caption));
+      }}
+      placeholder="Internal, Active"
+      style={{ ...fieldInputStyle, fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
+    />
+  );
+}
+
+function RelationshipListForNode({ nodeId, graph, setGraph, setSelected, selected }) {
+  const rels = graph.relationships.filter(r => r.fromId === nodeId || r.toId === nodeId);
+  if (rels.length === 0) return <div style={{ fontSize: 11, color: "#475569", marginTop: 8 }}>No relationships.</div>;
+
+  const nodeMap = {};
+  graph.nodes.forEach(n => { nodeMap[n.id] = n; });
+
+  return (
+    <div style={{ marginTop: 10 }}>
+      <span style={labelStyle}>Relationships ({rels.length})</span>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 4 }}>
+        {rels.map(r => {
+          const isSelf = r.fromId === r.toId;
+          const otherId = r.fromId === nodeId ? r.toId : r.fromId;
+          const otherNode = nodeMap[otherId];
+          const direction = r.fromId === nodeId ? "→" : "←";
+          const isActive = selected?.type === "relationship" && selected?.id === r.id;
+          return (
+            <div key={r.id}
+              onClick={() => setSelected({ type: "relationship", id: r.id })}
+              style={{
+                display: "flex", alignItems: "center", gap: 6, padding: "5px 8px",
+                background: isActive ? "#1e3a5f" : "#0f172a", border: `1px solid ${isActive ? "#3b82f6" : "#1e293b"}`,
+                borderRadius: 6, cursor: "pointer", transition: "all 0.15s",
+              }}>
+              <span style={{ fontSize: 11, color: "#64748b", minWidth: 14, textAlign: "center" }}>{isSelf ? "↻" : direction}</span>
+              <span style={{ fontSize: 11, color: "#93c5fd", fontFamily: "'JetBrains Mono', monospace", fontWeight: 600, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                :{r.type}
+              </span>
+              {!isSelf && <span style={{ fontSize: 10, color: "#475569" }}>{otherNode?.caption || otherId}</span>}
+              {isSelf && <span style={{ fontSize: 10, color: "#475569" }}>self</span>}
+              <button onClick={(e) => {
+                e.stopPropagation();
+                setGraph(g => ({ ...g, relationships: g.relationships.filter(x => x.id !== r.id) }));
+                if (isActive) setSelected({ type: "node", id: nodeId });
+              }} style={{ background: "#7f1d1d", border: "none", color: "#fca5a5", borderRadius: 3, cursor: "pointer", fontSize: 10, padding: "1px 6px", fontWeight: 600, flexShrink: 0 }}>✕</button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Inspector({ selected, graph, setGraph, setSelected }) {
+  if (!selected) {
+    return (
+      <div style={{ padding: 20, color: "#64748b", fontSize: 13 }}>
+        <p style={{ marginBottom: 12 }}>Click a node or relationship to edit.</p>
+        <p style={{ marginBottom: 12 }}><strong style={{ color: "#94a3b8" }}>Add Node</strong> button or <strong style={{ color: "#94a3b8" }}>double-click</strong> to create a node.</p>
+        <p style={{ marginBottom: 12 }}><strong style={{ color: "#94a3b8" }}>Drag from node edge</strong> to another node to create a relationship.</p>
+        <p style={{ marginBottom: 12 }}><strong style={{ color: "#94a3b8" }}>Scroll wheel</strong> to zoom in/out.</p>
+        <p style={{ fontSize: 11, color: "#475569" }}>Relationships must connect to a target node.</p>
+      </div>
+    );
+  }
+
+  if (selected.type === "node") {
+    const node = graph.nodes.find(n => n.id === selected.id);
+    if (!node) return null;
+    const updateNode = (patch) => setGraph(g => ({ ...g, nodes: g.nodes.map(n => n.id === node.id ? { ...n, ...patch } : n) }));
+    const deleteNode = () => {
+      setGraph(g => ({ ...g, nodes: g.nodes.filter(n => n.id !== node.id), relationships: g.relationships.filter(r => r.fromId !== node.id && r.toId !== node.id) }));
+      setSelected(null);
+    };
+
+    return (
+      <div style={{ padding: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+          <span style={{ fontWeight: 700, fontSize: 13, textTransform: "uppercase", letterSpacing: 1, color: "#e2e8f0" }}>Node</span>
+          <button onClick={deleteNode} style={{ background: "#7f1d1d", border: "none", color: "#fca5a5", borderRadius: 4, cursor: "pointer", fontSize: 11, padding: "3px 10px", fontWeight: 600 }}>Delete</button>
+        </div>
+        <span style={labelStyle}>Primary label (caption)</span>
+        <input
+          value={node.caption}
+          onChange={e => {
+            const newCaption = e.target.value;
+            // The labels array is always [caption, ...additionalLabels]. When
+            // the caption changes, keep the additional labels intact and just
+            // swap the first element — preserving things like ["Account",
+            // "Internal"] → ["BankAccount", "Internal"] as the user types.
+            const extras = (node.labels || []).slice(1);
+            const newLabels = newCaption ? [newCaption, ...extras] : extras;
+            updateNode({ caption: newCaption, labels: newLabels });
+          }}
+          style={fieldInputStyle}
+        />
+        <span style={labelStyle}>Additional labels</span>
+        <AdditionalLabelsInput
+          nodeId={node.id}
+          extras={(node.labels || []).slice(1)}
+          caption={node.caption}
+          onChange={extras => {
+            const newLabels = node.caption ? [node.caption, ...extras] : extras;
+            updateNode({ labels: newLabels });
+          }}
+        />
+        <div style={{ fontSize: 10, color: "#64748b", marginTop: -6, marginBottom: 10 }}>
+          Comma-separated. Exported as <code style={{ color: "#94a3b8" }}>:{node.caption || "Label"}{(node.labels || []).slice(1).map(l => ":" + l).join("")}</code>
+        </div>
+        <span style={labelStyle}>Color</span>
+        <div style={{ display: "flex", gap: 6, marginTop: 4, marginBottom: 10, flexWrap: "wrap" }}>
+          {COLORS.map(c => (
+            <div key={c} onClick={() => updateNode({ style: { ...node.style, color: c } })} style={{
+              width: 22, height: 22, borderRadius: "50%", background: c, cursor: "pointer",
+              border: node.style.color === c ? "2px solid #fff" : "2px solid transparent", transition: "border 0.15s"
+            }} />
+          ))}
+        </div>
+        <span style={labelStyle}>Radius</span>
+        <input type="range" min={30} max={80} value={node.style.radius} onChange={e => updateNode({ style: { ...node.style, radius: +e.target.value } })} style={{ width: "100%", marginTop: 2, marginBottom: 10 }} />
+        <PropertyEditor properties={node.properties} onChange={p => updateNode({ properties: p })} />
+        <RelationshipListForNode nodeId={node.id} graph={graph} setGraph={setGraph} setSelected={setSelected} selected={selected} />
+      </div>
+    );
+  }
+
+  if (selected.type === "relationship") {
+    const rel = graph.relationships.find(r => r.id === selected.id);
+    if (!rel) return null;
+    const updateRel = (patch) => setGraph(g => ({ ...g, relationships: g.relationships.map(r => r.id === rel.id ? { ...r, ...patch } : r) }));
+    const deleteRel = () => { setGraph(g => ({ ...g, relationships: g.relationships.filter(r => r.id !== rel.id) })); setSelected(null); };
+    const reverseRel = () => updateRel({ fromId: rel.toId, toId: rel.fromId });
+    const nodeMap = {};
+    graph.nodes.forEach(n => { nodeMap[n.id] = n; });
+    const fromNode = nodeMap[rel.fromId];
+    const toNode = nodeMap[rel.toId];
+
+    return (
+      <div style={{ padding: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+          <span style={{ fontWeight: 700, fontSize: 13, textTransform: "uppercase", letterSpacing: 1, color: "#e2e8f0" }}>Relationship</span>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button onClick={reverseRel} style={{ background: "#1e3a5f", border: "none", color: "#93c5fd", borderRadius: 4, cursor: "pointer", fontSize: 11, padding: "3px 10px", fontWeight: 600 }}>⇄ Reverse</button>
+            <button onClick={deleteRel} style={{ background: "#7f1d1d", border: "none", color: "#fca5a5", borderRadius: 4, cursor: "pointer", fontSize: 11, padding: "3px 10px", fontWeight: 600 }}>Delete</button>
+          </div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 12, padding: "6px 10px", background: "#0b1121", borderRadius: 6, border: "1px solid #1e293b" }}>
+          <span style={{ fontSize: 11, color: fromNode?.style.color || "#94a3b8", fontWeight: 700 }}>{fromNode?.caption || rel.fromId}</span>
+          <span style={{ fontSize: 11, color: "#475569" }}>→</span>
+          <span style={{ fontSize: 11, color: toNode?.style.color || "#94a3b8", fontWeight: 700 }}>{toNode?.caption || rel.toId}</span>
+        </div>
+        <span style={labelStyle}>Type</span>
+        <input value={rel.type} onChange={e => updateRel({ type: e.target.value })} style={{ ...fieldInputStyle, fontFamily: "'JetBrains Mono', monospace" }} />
+        <PropertyEditor properties={rel.properties} onChange={p => updateRel({ properties: p })} />
+      </div>
+    );
+  }
+  return null;
+}
+
+function ExportModal({ graph, onClose }) {
+  const [tab, setTab] = useState("json");
+  const content = tab === "json" ? toArrowsJSON(graph) : toCypher(graph);
+  const [copied, setCopied] = useState(false);
+  const preRef = useRef(null);
+
+  const copy = () => {
+    const ta = document.createElement("textarea");
+    ta.value = content;
+    ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try { document.execCommand("copy"); } catch (e) {}
+    document.body.removeChild(ta);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 3000);
+  };
+
+  const selectAll = () => {
+    if (preRef.current) {
+      const range = document.createRange();
+      range.selectNodeContents(preRef.current);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  };
+
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 999 }} onClick={onClose}>
+      <div onClick={e => e.stopPropagation()} style={{ background: "#0f172a", border: "1px solid #1e293b", borderRadius: 12, width: 620, maxHeight: "80vh", display: "flex", flexDirection: "column", boxShadow: "0 25px 50px rgba(0,0,0,0.5)" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px", borderBottom: "1px solid #1e293b" }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: "#e2e8f0" }}>Export Graph</span>
+          <button onClick={onClose} style={{ background: "none", border: "none", color: "#64748b", cursor: "pointer", fontSize: 18 }}>✕</button>
+        </div>
+        <div style={{ display: "flex", gap: 0, borderBottom: "1px solid #1e293b" }}>
+          {["json", "cypher"].map(t => (
+            <button key={t} onClick={() => { setTab(t); setCopied(false); }} style={{ flex: 1, padding: "10px 0", border: "none", cursor: "pointer", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, background: tab === t ? "#1e293b" : "transparent", color: tab === t ? "#e2e8f0" : "#64748b", borderBottom: tab === t ? "2px solid #4C8BF5" : "2px solid transparent" }}>
+              {t === "json" ? "Arrows JSON" : "Cypher"}
+            </button>
+          ))}
+        </div>
+        <pre ref={preRef} onClick={selectAll} style={{ flex: 1, overflow: "auto", padding: 20, margin: 0, fontSize: 12, fontFamily: "'JetBrains Mono', monospace", color: "#94a3b8", lineHeight: 1.6, whiteSpace: "pre-wrap", userSelect: "text", WebkitUserSelect: "text", cursor: "text" }}>{content}</pre>
+        <div style={{ padding: "12px 20px", borderTop: "1px solid #1e293b", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <span style={{ fontSize: 11, color: "#64748b" }}>{copied ? "Now paste into chat to continue with data generation" : "Click the code above to select all, or use the button"}</span>
+          <button onClick={copy} style={{ background: copied ? "#30A46C" : "#4C8BF5", border: "none", color: "#fff", borderRadius: 6, cursor: "pointer", fontSize: 13, padding: "9px 20px", fontWeight: 600, minWidth: 160, transition: "background 0.2s" }}>
+            {copied ? "✓ Copied to Clipboard!" : ("Copy " + (tab === "json" ? "JSON" : "Cypher"))}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ImportModal({ onImport, onClose }) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState(null);
+  const handleImport = () => {
+    try {
+      const parsed = JSON.parse(text);
+      const g = parsed.graph || parsed;
+      if (!g.nodes || !g.relationships) throw new Error("Invalid");
+      // arrows.app puts default radius (and other styling) in a top-level
+      // `style` block. Pick up the radius default once so per-node overrides
+      // can fall back to it, matching arrows.app's own rendering.
+      const topRadius = (g.style && typeof g.style.radius === "number") ? g.style.radius : null;
+      onImport({
+        nodes: g.nodes.map(n => {
+          // Caption derivation: arrows.app commonly emits caption="" and
+          // expects labels[0] to drive the display. Treat empty/whitespace
+          // captions as missing so the fallback to labels[0] kicks in.
+          const rawCaption = (n.caption && n.caption.trim()) ? n.caption : null;
+          const caption = rawCaption || (n.labels?.[0]) || "";
+          // Enforce labels = [caption, ...rest], no dupes, no empties — same
+          // invariant inject.py enforces on the CLI side.
+          const seen = new Set();
+          const extras = [];
+          for (const lab of (n.labels || [])) {
+            if (typeof lab !== "string") continue;
+            const trimmed = lab.trim();
+            if (!trimmed || trimmed === caption || seen.has(trimmed)) continue;
+            seen.add(trimmed);
+            extras.push(trimmed);
+          }
+          const labels = caption ? [caption, ...extras] : extras;
+          // Style: accept BOTH our internal `color` (camelCase) and arrows.app's
+          // `node-color` (kebab-case). Radius can be node-level OR inherited
+          // from the top-level style block.
+          const ns = n.style || {};
+          const color = ns.color || ns["node-color"] || COLORS[Math.floor(Math.random() * COLORS.length)];
+          const radius = ns.radius || topRadius || 50;
+          return {
+            id: n.id || uid(),
+            position: n.position || { x: 200 + Math.random() * 400, y: 200 + Math.random() * 300 },
+            caption,
+            labels,
+            properties: n.properties || {},
+            style: { color, radius },
+          };
+        }),
+        relationships: g.relationships.map(r => ({ id: r.id || rid(), type: r.type || "RELATED_TO", fromId: r.fromId || r.startNode, toId: r.toId || r.endNode, properties: r.properties || {} })),
+        style: g.style || {},
+      });
+      onClose();
+    } catch { setError("Invalid JSON. Paste an arrows.app export."); }
+  };
+
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 999 }} onClick={onClose}>
+      <div onClick={e => e.stopPropagation()} style={{ background: "#0f172a", border: "1px solid #1e293b", borderRadius: 12, width: 550, boxShadow: "0 25px 50px rgba(0,0,0,0.5)" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px", borderBottom: "1px solid #1e293b" }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: "#e2e8f0" }}>Import Arrows JSON</span>
+          <button onClick={onClose} style={{ background: "none", border: "none", color: "#64748b", cursor: "pointer", fontSize: 18 }}>✕</button>
+        </div>
+        <div style={{ padding: 20 }}>
+          <textarea value={text} onChange={e => { setText(e.target.value); setError(null); }} placeholder='Paste arrows.app JSON here...' rows={12} style={{ width: "100%", background: "#1e293b", border: "1px solid #334155", color: "#e2e8f0", borderRadius: 6, padding: 12, fontSize: 12, fontFamily: "'JetBrains Mono', monospace", resize: "vertical", boxSizing: "border-box" }} />
+          {error && <div style={{ color: "#f87171", fontSize: 12, marginTop: 6 }}>{error}</div>}
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", padding: "12px 20px", borderTop: "1px solid #1e293b", gap: 8 }}>
+          <button onClick={onClose} style={{ background: "#1e293b", border: "1px solid #334155", color: "#e2e8f0", borderRadius: 6, cursor: "pointer", fontSize: 12, padding: "8px 16px" }}>Cancel</button>
+          <button onClick={handleImport} style={{ background: "#4C8BF5", border: "none", color: "#fff", borderRadius: 6, cursor: "pointer", fontSize: 12, padding: "8px 16px", fontWeight: 600 }}>Import</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Main ---
+export default function GraphEditor() {
+  const [graph, setGraph] = useState(initialGraph);
+  const [selected, setSelected] = useState(null);
+  const [dragging, setDragging] = useState(null);
+  const [drawingRel, setDrawingRel] = useState(null);
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const [showExport, setShowExport] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [panning, setPanning] = useState(null);
+  const [zoom, setZoom] = useState(1);
+  const [hoveredTarget, setHoveredTarget] = useState(null);
+  const [relDropFailed, setRelDropFailed] = useState(false);
+  const svgRef = useRef(null);
+
+  const MIN_ZOOM = 0.15;
+  const MAX_ZOOM = 3;
+
+  const toSVG = useCallback((clientX, clientY) => {
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return { x: clientX, y: clientY };
+    return { x: (clientX - rect.left - pan.x) / zoom, y: (clientY - rect.top - pan.y) / zoom };
+  }, [pan, zoom]);
+
+  const handleCanvasDoubleClick = (e) => {
+    if (e.target !== svgRef.current && e.target.tagName !== "rect") return;
+    const pos = toSVG(e.clientX, e.clientY);
+    const id = uid();
+    const color = COLORS[graph.nodes.length % COLORS.length];
+    setGraph(g => ({ ...g, nodes: [...g.nodes, { id, position: pos, caption: "Node", labels: ["Node"], properties: {}, style: { color, radius: 50 } }] }));
+    setSelected({ type: "node", id });
+  };
+
+  const addNodeAtCenter = () => {
+    const rect = svgRef.current?.getBoundingClientRect();
+    const cx = rect ? (rect.width / 2 - pan.x) / zoom : 400;
+    const cy = rect ? (rect.height / 2 - pan.y) / zoom : 300;
+    const jitter = () => (Math.random() - 0.5) * 60;
+    const id = uid();
+    const color = COLORS[graph.nodes.length % COLORS.length];
+    setGraph(g => ({ ...g, nodes: [...g.nodes, { id, position: { x: cx + jitter(), y: cy + jitter() }, caption: "Node", labels: ["Node"], properties: {}, style: { color, radius: 50 } }] }));
+    setSelected({ type: "node", id });
+  };
+
+  const applyZoom = useCallback((newZoom, centerX, centerY) => {
+    const nz = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newZoom));
+    const ratio = nz / zoom;
+    setPan(p => ({ x: centerX - ratio * (centerX - p.x), y: centerY - ratio * (centerY - p.y) }));
+    setZoom(nz);
+  }, [zoom]);
+
+  const handleMouseDown = (e) => {
+    if (e.button === 1 || (e.button === 0 && (e.target === svgRef.current || e.target.tagName === "rect"))) {
+      setPanning({ startX: e.clientX, startY: e.clientY, startPanX: pan.x, startPanY: pan.y });
+    }
+  };
+
+  const handleWheel = useCallback((e) => {
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const factor = e.deltaY > 0 ? 0.9 : 1.1;
+    applyZoom(zoom * factor, mx, my);
+  }, [zoom, applyZoom]);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    svg.addEventListener("wheel", handleWheel, { passive: false });
+    return () => svg.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  const handleMouseMove = useCallback((e) => {
+    const svgPt = toSVG(e.clientX, e.clientY);
+    setMousePos(svgPt);
+
+    if (panning) {
+      setPan({ x: panning.startPanX + (e.clientX - panning.startX), y: panning.startPanY + (e.clientY - panning.startY) });
+      return;
+    }
+    if (dragging) {
+      setGraph(g => ({ ...g, nodes: g.nodes.map(n => n.id === dragging.id ? { ...n, position: { x: svgPt.x + dragging.offX, y: svgPt.y + dragging.offY } } : n) }));
+    }
+    if (drawingRel) {
+      const target = graph.nodes.find(n => Math.sqrt((n.position.x - svgPt.x) ** 2 + (n.position.y - svgPt.y) ** 2) <= n.style.radius + 10);
+      setHoveredTarget(target ? target.id : null);
+    }
+  }, [dragging, panning, toSVG, drawingRel, graph.nodes]);
+
+  const handleMouseUp = useCallback((e) => {
+    if (panning) { setPanning(null); return; }
+    if (drawingRel) {
+      const svgPt = toSVG(e.clientX, e.clientY);
+      const target = graph.nodes.find(n => Math.sqrt((n.position.x - svgPt.x) ** 2 + (n.position.y - svgPt.y) ** 2) <= n.style.radius + 10);
+      if (target) {
+        const id = rid();
+        setGraph(g => ({ ...g, relationships: [...g.relationships, { id, type: "RELATED_TO", fromId: drawingRel.fromId, toId: target.id, properties: {} }] }));
+        setSelected({ type: "relationship", id });
+      } else {
+        setRelDropFailed(true);
+        setTimeout(() => setRelDropFailed(false), 1200);
+      }
+      setDrawingRel(null);
+      setHoveredTarget(null);
+    }
+    setDragging(null);
+  }, [drawingRel, graph.nodes, panning, toSVG]);
+
+  useEffect(() => {
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => { window.removeEventListener("mousemove", handleMouseMove); window.removeEventListener("mouseup", handleMouseUp); };
+  }, [handleMouseMove, handleMouseUp]);
+
+  const nodeMap = {};
+  graph.nodes.forEach(n => { nodeMap[n.id] = n; });
+
+  const relGroups = {};
+  graph.relationships.forEach(r => {
+    const key = [r.fromId, r.toId].sort().join("-");
+    if (!relGroups[key]) relGroups[key] = [];
+    relGroups[key].push(r.id);
+  });
+
+  const selfLoopGroups = {};
+  graph.relationships.forEach(r => {
+    if (r.fromId === r.toId) {
+      if (!selfLoopGroups[r.fromId]) selfLoopGroups[r.fromId] = [];
+      selfLoopGroups[r.fromId].push(r.id);
+    }
+  });
+
+  const zoomPercent = Math.round(zoom * 100);
+  const zoomBtnStyle = { background: "#0f172a", border: "1px solid #1e293b", color: "#94a3b8", borderRadius: 6, cursor: "pointer", fontSize: 14, width: 32, height: 32, display: "flex", alignItems: "center", justifyContent: "center", fontWeight: 700 };
+
+  return (
+    <div style={{ width: "100%", height: "100vh", display: "flex", fontFamily: "'Inter', -apple-system, sans-serif", background: "#0b1121", color: "#e2e8f0", overflow: "hidden" }}>
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+      <div style={{ flex: 1, position: "relative" }}>
+        {/* Toolbar */}
+        <div style={{ position: "absolute", top: 12, left: 12, right: 12, zIndex: 10, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, background: "#0f172a", border: "1px solid #1e293b", borderRadius: 8, padding: "6px 14px" }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#4C8BF5" strokeWidth="2"><circle cx="6" cy="6" r="3"/><circle cx="18" cy="18" r="3"/><line x1="8.5" y1="8.5" x2="15.5" y2="15.5"/></svg>
+              <span style={{ fontWeight: 700, fontSize: 14, color: "#e2e8f0" }}>Graph Schema Editor</span>
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button onClick={addNodeAtCenter} style={{ background: "#0f172a", border: "1px solid #1e293b", color: "#94a3b8", borderRadius: 6, cursor: "pointer", fontSize: 12, padding: "7px 14px", fontWeight: 500, display: "flex", alignItems: "center", gap: 5 }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+              Add Node
+            </button>
+            <button onClick={() => setShowImport(true)} style={{ background: "#0f172a", border: "1px solid #1e293b", color: "#94a3b8", borderRadius: 6, cursor: "pointer", fontSize: 12, padding: "7px 14px", fontWeight: 500 }}>Import</button>
+            <button onClick={() => setShowExport(true)} style={{ background: "#4C8BF5", border: "none", color: "#fff", borderRadius: 6, cursor: "pointer", fontSize: 12, padding: "7px 14px", fontWeight: 600 }}>Export</button>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div style={{ position: "absolute", bottom: 12, left: 12, right: 12, zIndex: 10, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", gap: 8, fontSize: 11, color: "#64748b" }}>
+            <span style={{ background: "#0f172a", border: "1px solid #1e293b", borderRadius: 6, padding: "4px 10px" }}>{graph.nodes.length} nodes</span>
+            <span style={{ background: "#0f172a", border: "1px solid #1e293b", borderRadius: 6, padding: "4px 10px" }}>{graph.relationships.length} rels</span>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 4, background: "#0f172a", border: "1px solid #1e293b", borderRadius: 8, padding: 4 }}>
+            <button onClick={() => { const rect = svgRef.current?.getBoundingClientRect(); applyZoom(zoom * 0.8, rect ? rect.width / 2 : 400, rect ? rect.height / 2 : 300); }} style={zoomBtnStyle}>−</button>
+            <button onClick={() => { setPan({ x: 0, y: 0 }); setZoom(1); }} style={{ ...zoomBtnStyle, width: 52, fontSize: 11, fontWeight: 600, fontFamily: "'JetBrains Mono', monospace" }}>{zoomPercent}%</button>
+            <button onClick={() => { const rect = svgRef.current?.getBoundingClientRect(); applyZoom(zoom * 1.25, rect ? rect.width / 2 : 400, rect ? rect.height / 2 : 300); }} style={zoomBtnStyle}>+</button>
+          </div>
+        </div>
+
+        <svg ref={svgRef} style={{ width: "100%", height: "100%", cursor: panning ? "grabbing" : dragging ? "grabbing" : "default" }} onDoubleClick={handleCanvasDoubleClick} onMouseDown={handleMouseDown}>
+          <defs>
+            <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse" patternTransform={`translate(${pan.x % (40 * zoom)} ${pan.y % (40 * zoom)}) scale(${zoom})`}>
+              <circle cx="20" cy="20" r="0.5" fill="#1e293b" />
+            </pattern>
+            <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto" markerUnits="strokeWidth"><polygon points="0 0, 10 3.5, 0 7" fill="#64748b" /></marker>
+            <marker id="arrowhead-active" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto" markerUnits="strokeWidth"><polygon points="0 0, 10 3.5, 0 7" fill="#4C8BF5" /></marker>
+            <marker id="arrowhead-drawing" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto" markerUnits="strokeWidth"><polygon points="0 0, 10 3.5, 0 7" fill="#4C8BF5" opacity="0.6" /></marker>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#grid)" />
+
+          <g transform={`translate(${pan.x}, ${pan.y}) scale(${zoom})`}>
+            {/* Relationships */}
+            {graph.relationships.map(rel => {
+              const from = nodeMap[rel.fromId];
+              const to = nodeMap[rel.toId];
+              if (!from || !to) return null;
+              const isSelected = selected?.type === "relationship" && selected?.id === rel.id;
+
+              if (rel.fromId === rel.toId) {
+                const siblings = selfLoopGroups[rel.fromId] || [];
+                const idx = siblings.indexOf(rel.id);
+                const total = siblings.length;
+                const { path, midX, midY } = getSelfLoopPath(from.position.x, from.position.y, from.style.radius, idx, total);
+                return (
+                  <g key={rel.id}>
+                    <path d={path} fill="none" stroke="transparent" strokeWidth={22} style={{ cursor: "pointer" }} onClick={(e) => { e.stopPropagation(); setSelected({ type: "relationship", id: rel.id }); }} />
+                    <path d={path} fill="none" stroke={isSelected ? "#4C8BF5" : "#64748b"} strokeWidth={isSelected ? 2.5 : 1.5} markerEnd={isSelected ? "url(#arrowhead-active)" : "url(#arrowhead)"} />
+                    {rel.type && (
+                      <g transform={`translate(${midX}, ${midY})`}>
+                        <rect x={-rel.type.length * 3.2 - 6} y={-8} width={rel.type.length * 6.4 + 12} height={16} rx={4} fill="#0b1121" opacity={0.9} />
+                        <text x={0} y={0} textAnchor="middle" dominantBaseline="central" fill={isSelected ? "#bfdbfe" : "#e2e8f0"} fontSize="10" fontFamily="'JetBrains Mono', monospace" fontWeight="600" style={{ pointerEvents: "none" }}>{rel.type}</text>
+                      </g>
+                    )}
+                  </g>
+                );
+              }
+
+              const pairKey = [rel.fromId, rel.toId].sort().join("-");
+              const siblings = relGroups[pairKey] || [];
+              const idx = siblings.indexOf(rel.id);
+              const siblingCount = siblings.length;
+              // Give rels in the same direction (from->to) one sign and the
+              // reverse direction (to->from) the opposite sign, so back-and-forth
+              // pairs naturally separate without the user having to reorder.
+              const sortedPair = [rel.fromId, rel.toId].sort();
+              const directionSign = rel.fromId === sortedPair[0] ? 1 : -1;
+              // Perpendicular fan: each sibling is offset off the centerline.
+              // 36px step keeps labels readable without pushing edges too far.
+              const laneOffset = siblingCount > 1
+                ? (idx - (siblingCount - 1) / 2) * 36 * directionSign
+                : 0;
+
+              const ep = getEdgePoints(from.position, to.position, from.style.radius, to.style.radius);
+              const dx = ep.x2 - ep.x1; const dy = ep.y2 - ep.y1; const l = Math.sqrt(dx * dx + dy * dy) || 1;
+              const nx = -dy / l; const ny = dx / l;
+
+              // Offset the start/end points perpendicular to the line so each
+              // sibling leaves and arrives at a different spot on the node
+              // boundary — this is what actually prevents visual overlap at
+              // the arrowhead.
+              const endpointOffset = laneOffset * 0.45;
+              const x1 = ep.x1 + nx * endpointOffset;
+              const y1 = ep.y1 + ny * endpointOffset;
+              const x2 = ep.x2 + nx * endpointOffset;
+              const y2 = ep.y2 + ny * endpointOffset;
+
+              // Midpoint bulge: curve arcs out further than the endpoint offset
+              // so the label sits in clear space between the edges.
+              const midX = (x1 + x2) / 2 + nx * laneOffset * 0.9;
+              const midY = (y1 + y2) / 2 + ny * laneOffset * 0.9;
+              const pathD = laneOffset !== 0
+                ? `M ${x1} ${y1} Q ${midX} ${midY} ${x2} ${y2}`
+                : `M ${x1} ${y1} L ${x2} ${y2}`;
+
+              return (
+                <g key={rel.id}>
+                  <path d={pathD} fill="none" stroke="transparent" strokeWidth={16} style={{ cursor: "pointer" }} onClick={(e) => { e.stopPropagation(); setSelected({ type: "relationship", id: rel.id }); }} />
+                  <path d={pathD} fill="none" stroke={isSelected ? "#4C8BF5" : "#64748b"} strokeWidth={isSelected ? 2.5 : 1.5} markerEnd={isSelected ? "url(#arrowhead-active)" : "url(#arrowhead)"} />
+                  {rel.type && (
+                    <g transform={`translate(${midX}, ${midY})`}>
+                      <rect x={-rel.type.length * 3.2 - 6} y={-16} width={rel.type.length * 6.4 + 12} height={16} rx={4} fill="#0b1121" opacity={0.85} />
+                      <text x={0} y={-8} textAnchor="middle" dominantBaseline="central" fill={isSelected ? "#bfdbfe" : "#e2e8f0"} fontSize="10" fontFamily="'JetBrains Mono', monospace" fontWeight="600" style={{ pointerEvents: "none" }}>{rel.type}</text>
+                    </g>
+                  )}
+                  {Object.keys(rel.properties || {}).length > 0 && <text x={midX} y={midY} textAnchor="middle" dy="10" fill={isSelected ? "#cbd5e1" : "#94a3b8"} fontSize="9" fontFamily="'JetBrains Mono', monospace" style={{ pointerEvents: "none" }}>{"{"}{Object.keys(rel.properties).join(", ")}{"}"}</text>}
+                </g>
+              );
+            })}
+
+            {drawingRel && (() => {
+              const from = nodeMap[drawingRel.fromId];
+              if (!from) return null;
+              const ep = getEdgePoints(from.position, mousePos, from.style.radius, 0);
+              const hasTarget = hoveredTarget !== null;
+              return <line x1={ep.x1} y1={ep.y1} x2={mousePos.x} y2={mousePos.y} stroke={hasTarget ? "#30A46C" : "#4C8BF5"} strokeWidth={2} strokeDasharray="6 4" opacity={hasTarget ? 0.9 : 0.5} markerEnd="url(#arrowhead-drawing)" />;
+            })()}
+
+            {/* Nodes */}
+            {graph.nodes.map(node => {
+              const isSelected = selected?.type === "node" && selected?.id === node.id;
+              const props = Object.entries(node.properties || {});
+              return (
+                <g key={node.id} style={{ cursor: "grab" }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    const svgPt = toSVG(e.clientX, e.clientY);
+                    const dist = Math.sqrt((node.position.x - svgPt.x) ** 2 + (node.position.y - svgPt.y) ** 2);
+                    if (dist > node.style.radius * 0.7) {
+                      setDrawingRel({ fromId: node.id });
+                    } else {
+                      setDragging({ id: node.id, offX: node.position.x - svgPt.x, offY: node.position.y - svgPt.y });
+                      setSelected({ type: "node", id: node.id });
+                    }
+                  }}
+                  onClick={(e) => { e.stopPropagation(); setSelected({ type: "node", id: node.id }); }}
+                >
+                  <circle cx={node.position.x} cy={node.position.y} r={node.style.radius + 12} fill="transparent" stroke={isSelected ? "#4C8BF5" : "transparent"} strokeWidth={1} strokeDasharray="4 4" opacity={0.3} />
+                  {drawingRel && hoveredTarget === node.id && (
+                    <circle cx={node.position.x} cy={node.position.y} r={node.style.radius + 8} fill="none" stroke={drawingRel.fromId === node.id ? "#F59E0B" : "#30A46C"} strokeWidth={3} opacity={0.7}>
+                      <animate attributeName="r" from={node.style.radius + 6} to={node.style.radius + 14} dur="0.8s" repeatCount="indefinite" />
+                      <animate attributeName="opacity" from="0.7" to="0.2" dur="0.8s" repeatCount="indefinite" />
+                    </circle>
+                  )}
+                  <circle cx={node.position.x} cy={node.position.y} r={node.style.radius} fill={node.style.color + "18"} stroke={isSelected ? "#4C8BF5" : node.style.color} strokeWidth={isSelected ? 3 : 2} style={{ transition: "stroke 0.15s, stroke-width 0.15s" }} />
+                  <circle cx={node.position.x} cy={node.position.y} r={node.style.radius - 4} fill="none" stroke={node.style.color} strokeWidth={0.5} opacity={0.3} />
+                  <text x={node.position.x} y={node.position.y} textAnchor="middle" dominantBaseline="central" fill="#ffffff" fontSize={node.caption.length > 10 ? 11 : 13} fontWeight="700" fontFamily="'Inter', sans-serif" style={{ pointerEvents: "none", textTransform: "uppercase", letterSpacing: 0.5 }}>{node.caption}</text>
+                  {/* Secondary labels (arrows.app convention): pills below the circle, above properties. */}
+                  {(() => {
+                    const extras = (node.labels || []).slice(1);
+                    if (extras.length === 0) return null;
+                    // Pre-compute per-pill widths so the row is centred as a group.
+                    const pillPadX = 6;
+                    const charW = 6;
+                    const gap = 4;
+                    const widths = extras.map(l => Math.max(24, l.length * charW + pillPadX * 2));
+                    const totalW = widths.reduce((a, b) => a + b, 0) + gap * (extras.length - 1);
+                    const rowY = node.position.y + node.style.radius + 8;
+                    let cursorX = node.position.x - totalW / 2;
+                    return extras.map((label, i) => {
+                      const w = widths[i];
+                      const x = cursorX;
+                      cursorX += w + gap;
+                      return (
+                        <g key={label + i} style={{ pointerEvents: "none" }}>
+                          <rect x={x} y={rowY} width={w} height={14} rx={7} fill={node.style.color + "30"} stroke={node.style.color} strokeWidth={0.75} />
+                          <text x={x + w / 2} y={rowY + 7} textAnchor="middle" dominantBaseline="central" fill="#ffffff" fontSize="9" fontFamily="'JetBrains Mono', monospace" fontWeight="600" style={{ letterSpacing: 0.3 }}>:{label}</text>
+                        </g>
+                      );
+                    });
+                  })()}
+                  {props.map(([k, v], i) => {
+                    // Push properties down to make room for the label-pill row.
+                    const extrasCount = (node.labels || []).length - 1;
+                    const pillRowHeight = extrasCount > 0 ? 18 : 0;
+                    return (
+                      <text key={k} x={node.position.x} y={node.position.y + node.style.radius + 14 + pillRowHeight + i * 14} textAnchor="middle" fill="#cbd5e1" fontSize="10" fontFamily="'JetBrains Mono', monospace" style={{ pointerEvents: "none" }}>{k}: {v}</text>
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+
+      {/* Sidebar */}
+      <div style={{ width: 280, minWidth: 280, background: "#0f172a", borderLeft: "1px solid #1e293b", overflowY: "auto", display: "flex", flexDirection: "column" }}>
+        <div style={{ padding: "12px 16px", borderBottom: "1px solid #1e293b", fontWeight: 700, fontSize: 12, textTransform: "uppercase", letterSpacing: 1, color: "#64748b" }}>Inspector</div>
+        <Inspector selected={selected} graph={graph} setGraph={setGraph} setSelected={setSelected} />
+      </div>
+
+      {showExport && <ExportModal graph={graph} onClose={() => setShowExport(false)} />}
+      {showImport && <ImportModal onImport={g => setGraph(g)} onClose={() => setShowImport(false)} />}
+      {relDropFailed && (
+        <div style={{ position: "fixed", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "#1c1917", border: "1px solid #44403c", borderRadius: 8, padding: "10px 20px", color: "#fbbf24", fontSize: 13, fontWeight: 500, display: "flex", alignItems: "center", gap: 8, zIndex: 1000, boxShadow: "0 8px 24px rgba(0,0,0,0.4)", animation: "fadeInUp 0.2s ease-out" }}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          Relationship must connect to a node
+        </div>
+      )}
+      <style>{`@keyframes fadeInUp { from { opacity: 0; transform: translateX(-50%) translateY(8px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }`}</style>
+    </div>
+  );
+}

--- a/neo4j-modeling-skill/references/account-takeover-fraud.json
+++ b/neo4j-modeling-skill/references/account-takeover-fraud.json
@@ -1,0 +1,277 @@
+{
+  "id": "account-takeover-fraud",
+  "name": "Account Takeover Fraud",
+  "description": "Detects ATO fraud using device fingerprinting, session behaviour, and chronological event chains (Authentication → contact changes → external account → fraudulent transfer). Forensic OLD_/NEW_ links preserve before-and-after state for investigations. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/account-takeover-fraud/",
+  "industry": "Financial Services",
+  "tags": [
+    "fraud",
+    "account-takeover",
+    "retail-banking",
+    "event-sequence",
+    "forensic"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 50 },
+        "caption": "Customer",
+        "labels": ["Customer"],
+        "properties": {
+          "customerId": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 150, "y": 350 },
+        "caption": "Account",
+        "labels": ["Account", "Internal"],
+        "properties": {
+          "accountNumber": "string",
+          "accountType": "string",
+          "openedDate": "datetime"
+        },
+        "style": { "color": "#009CE0", "radius": 55 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 900, "y": 50 },
+        "caption": "Country",
+        "labels": ["Country"],
+        "properties": {
+          "code": "string",
+          "name": "string"
+        },
+        "style": { "color": "#73D8FF", "radius": 40 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 150, "y": 50 },
+        "caption": "Device",
+        "labels": ["Device"],
+        "properties": {
+          "deviceId": "string",
+          "deviceType": "string",
+          "userAgent": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#D33115", "radius": 40 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": -100, "y": 200 },
+        "caption": "Session",
+        "labels": ["Session"],
+        "properties": {
+          "sessionId": "string",
+          "status": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#F44E3B", "radius": 45 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": -350, "y": 200 },
+        "caption": "IP",
+        "labels": ["IP"],
+        "properties": {
+          "ipAddress": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#E27300", "radius": 35 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": -600, "y": 200 },
+        "caption": "ISP",
+        "labels": ["ISP"],
+        "properties": {
+          "name": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FCC400", "radius": 35 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": -500, "y": 50 },
+        "caption": "Location",
+        "labels": ["Location"],
+        "properties": {
+          "city": "string",
+          "postCode": "string",
+          "country": "string",
+          "latitude": "float",
+          "longitude": "float",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FB9E00", "radius": 40 }
+      },
+      {
+        "id": "n8",
+        "position": { "x": 650, "y": 50 },
+        "caption": "Email",
+        "labels": ["Email"],
+        "properties": {
+          "address": "string",
+          "domain": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#AEA1FF", "radius": 40 }
+      },
+      {
+        "id": "n9",
+        "position": { "x": 650, "y": 200 },
+        "caption": "Phone",
+        "labels": ["Phone"],
+        "properties": {
+          "number": "string",
+          "countryCode": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FA28FF", "radius": 40 }
+      },
+      {
+        "id": "n10",
+        "position": { "x": 900, "y": 200 },
+        "caption": "Address",
+        "labels": ["Address"],
+        "properties": {
+          "addressLine1": "string",
+          "addressLine2": "string",
+          "postTown": "string",
+          "postCode": "string",
+          "region": "string",
+          "latitude": "float",
+          "longitude": "float",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FE9200", "radius": 45 }
+      },
+      {
+        "id": "n11",
+        "position": { "x": 400, "y": 400 },
+        "caption": "Authentication",
+        "labels": ["Authentication"],
+        "properties": {
+          "method": "string",
+          "status": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 45 }
+      },
+      {
+        "id": "n12",
+        "position": { "x": 400, "y": 500 },
+        "caption": "ChangePhone",
+        "labels": ["ChangePhone"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 40 }
+      },
+      {
+        "id": "n13",
+        "position": { "x": 400, "y": 600 },
+        "caption": "ChangeEmail",
+        "labels": ["ChangeEmail"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 40 }
+      },
+      {
+        "id": "n14",
+        "position": { "x": 400, "y": 700 },
+        "caption": "ChangeAddress",
+        "labels": ["ChangeAddress"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 40 }
+      },
+      {
+        "id": "n15",
+        "position": { "x": 400, "y": 800 },
+        "caption": "AddExternalAccount",
+        "labels": ["AddExternalAccount"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 45 }
+      },
+      {
+        "id": "n16",
+        "position": { "x": 400, "y": 900 },
+        "caption": "Transfer",
+        "labels": ["Transfer"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 40 }
+      },
+      {
+        "id": "n17",
+        "position": { "x": 150, "y": 900 },
+        "caption": "Transaction",
+        "labels": ["Transaction"],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime",
+          "message": "string",
+          "type": "string"
+        },
+        "style": { "color": "#16A5A5", "radius": 50 }
+      },
+      {
+        "id": "n18",
+        "position": { "x": -100, "y": 900 },
+        "caption": "Account",
+        "labels": ["Account", "External"],
+        "properties": {
+          "accountNumber": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_ACCOUNT", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "HAS_EMAIL", "fromId": "n0", "toId": "n8", "properties": {} },
+      { "id": "r2", "type": "HAS_PHONE", "fromId": "n0", "toId": "n9", "properties": {} },
+      { "id": "r3", "type": "HAS_ADDRESS", "fromId": "n0", "toId": "n10", "properties": {} },
+      { "id": "r4", "type": "HAS_SESSION", "fromId": "n0", "toId": "n4", "properties": {} },
+      { "id": "r5", "type": "IS_HOSTED", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r6", "type": "LOCATED_IN", "fromId": "n10", "toId": "n2", "properties": {} },
+      { "id": "r7", "type": "LOCATED_IN", "fromId": "n7", "toId": "n2", "properties": {} },
+      { "id": "r8", "type": "LOCATED_IN", "fromId": "n5", "toId": "n7", "properties": {} },
+      { "id": "r9", "type": "IS_ALLOCATED_TO", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r10", "type": "USED_BY", "fromId": "n3", "toId": "n0", "properties": {} },
+      { "id": "r11", "type": "SESSION_USES_DEVICE", "fromId": "n4", "toId": "n3", "properties": {} },
+      { "id": "r12", "type": "USES_IP", "fromId": "n4", "toId": "n5", "properties": {} },
+      { "id": "r13", "type": "CONNECTS", "fromId": "n0", "toId": "n11", "properties": {} },
+      { "id": "r14", "type": "HAS_AUTHENTICATION", "fromId": "n4", "toId": "n11", "properties": {} },
+      { "id": "r15", "type": "HAS_CHANGE_PHONE", "fromId": "n4", "toId": "n12", "properties": {} },
+      { "id": "r16", "type": "HAS_CHANGE_EMAIL", "fromId": "n4", "toId": "n13", "properties": {} },
+      { "id": "r17", "type": "HAS_CHANGE_ADDRESS", "fromId": "n4", "toId": "n14", "properties": {} },
+      { "id": "r18", "type": "HAS_ADD_EXTERNAL_ACCOUNT", "fromId": "n4", "toId": "n15", "properties": {} },
+      { "id": "r19", "type": "HAS_TRANSFER", "fromId": "n4", "toId": "n16", "properties": {} },
+      { "id": "r20", "type": "NEXT", "fromId": "n11", "toId": "n12", "properties": {} },
+      { "id": "r21", "type": "NEXT", "fromId": "n12", "toId": "n13", "properties": {} },
+      { "id": "r22", "type": "NEXT", "fromId": "n13", "toId": "n14", "properties": {} },
+      { "id": "r23", "type": "NEXT", "fromId": "n14", "toId": "n15", "properties": {} },
+      { "id": "r24", "type": "NEXT", "fromId": "n15", "toId": "n16", "properties": {} },
+      { "id": "r25", "type": "OLD_PHONE", "fromId": "n12", "toId": "n9", "properties": {} },
+      { "id": "r26", "type": "NEW_PHONE", "fromId": "n12", "toId": "n9", "properties": {} },
+      { "id": "r27", "type": "OLD_EMAIL", "fromId": "n13", "toId": "n8", "properties": {} },
+      { "id": "r28", "type": "NEW_EMAIL", "fromId": "n13", "toId": "n8", "properties": {} },
+      { "id": "r29", "type": "OLD_ADDRESS", "fromId": "n14", "toId": "n10", "properties": {} },
+      { "id": "r30", "type": "NEW_ADDRESS", "fromId": "n14", "toId": "n10", "properties": {} },
+      { "id": "r31", "type": "ADD_ACCOUNT", "fromId": "n15", "toId": "n18", "properties": {} },
+      { "id": "r32", "type": "HAS_TRANSACTION", "fromId": "n16", "toId": "n17", "properties": {} },
+      { "id": "r33", "type": "PERFORMS", "fromId": "n1", "toId": "n17", "properties": {} },
+      { "id": "r34", "type": "BENEFITS_TO", "fromId": "n17", "toId": "n18", "properties": {} }
+    ]
+  }
+}

--- a/neo4j-modeling-skill/references/attack-path-analysis.json
+++ b/neo4j-modeling-skill/references/attack-path-analysis.json
@@ -1,0 +1,181 @@
+{
+  "id": "attack-path-analysis",
+  "name": "Attack Path Analysis",
+  "description": "Extends the VPEM model with CAN_REACH for lateral movement simulation. Maps kill chains from initial foothold to crown jewel assets. Source: https://neo4j.com/developer/industry-use-cases/cybersecurity/attack-path-analysis/",
+  "industry": "Cybersecurity",
+  "tags": [
+    "attack-path",
+    "lateral-movement",
+    "APA",
+    "cybersecurity"
+  ],
+  "extends": "vulnerability-prioritization",
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 50
+        },
+        "caption": "ComputeInstance",
+        "labels": [
+          "ComputeInstance"
+        ],
+        "properties": {
+          "instanceId": "string",
+          "hostname": "string",
+          "publicIp": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 200
+        },
+        "caption": "Application",
+        "labels": [
+          "Application"
+        ],
+        "properties": {
+          "appId": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 650,
+          "y": 200
+        },
+        "caption": "CVE",
+        "labels": [
+          "CVE"
+        ],
+        "properties": {
+          "id": "string",
+          "baseScore": "float",
+          "kev_addedDate": "datetime"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 150,
+          "y": 400
+        },
+        "caption": "Identity",
+        "labels": [
+          "Identity"
+        ],
+        "properties": {
+          "identityId": "string",
+          "name": "string",
+          "privilegeLevel": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 400,
+          "y": 400
+        },
+        "caption": "IAMPolicy",
+        "labels": [
+          "IAMPolicy"
+        ],
+        "properties": {
+          "policyId": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#68CCCA",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 650,
+          "y": 400
+        },
+        "caption": "CloudService",
+        "labels": [
+          "CloudService"
+        ],
+        "properties": {
+          "resource_name": "string",
+          "tier": "string"
+        },
+        "style": {
+          "color": "#FCDC00",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HOSTED_ON",
+        "fromId": "n1",
+        "toId": "n0",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "IDENTIFIED_IN",
+        "fromId": "n2",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "RUNS_AS",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "ASSUMES",
+        "fromId": "n3",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "HAS_ACCESS_TO",
+        "fromId": "n4",
+        "toId": "n5",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "CAN_REACH",
+        "fromId": "n0",
+        "toId": "n0",
+        "properties": {
+          "port": "integer"
+        }
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/automated-facial-recognition.json
+++ b/neo4j-modeling-skill/references/automated-facial-recognition.json
@@ -1,0 +1,37 @@
+{
+  "id": "automated-facial-recognition",
+  "name": "Automated Facial Recognition",
+  "description": "Facial biometric matching using vector embeddings on Face nodes. Uses cosine similarity for identity verification. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/automated-facial-recognition/",
+  "industry": "Financial Services",
+  "tags": [
+    "facial-recognition",
+    "KYC",
+    "biometrics",
+    "vector-search"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 250
+        },
+        "caption": "Face",
+        "labels": [
+          "Face"
+        ],
+        "properties": {
+          "faceId": "string",
+          "embedding": "list_of_float"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 60
+        }
+      }
+    ],
+    "relationships": [],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/claims-fraud.json
+++ b/neo4j-modeling-skill/references/claims-fraud.json
@@ -1,0 +1,127 @@
+{
+  "id": "claims-fraud",
+  "name": "Insurance Claims Fraud",
+  "description": "Detects claims fraud via Claimant, Claim, MedicalProfessional, Vehicle connections. Source: https://neo4j.com/developer/industry-use-cases/insurance/claims-fraud/",
+  "industry": "Insurance",
+  "tags": [
+    "insurance",
+    "claims-fraud",
+    "crash-for-cash"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 150,
+          "y": 200
+        },
+        "caption": "Claimant",
+        "labels": [
+          "Claimant"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 450,
+          "y": 200
+        },
+        "caption": "Claim",
+        "labels": [
+          "Claim"
+        ],
+        "properties": {
+          "claimID": "string",
+          "date": "date",
+          "amountClaimed": "float"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 450,
+          "y": 450
+        },
+        "caption": "MedicalProfessional",
+        "labels": [
+          "MedicalProfessional"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 150,
+          "y": 450
+        },
+        "caption": "Vehicle",
+        "labels": [
+          "Vehicle"
+        ],
+        "properties": {
+          "VIN": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_CLAIM",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "TREATED_BY",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "OWNS",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "INVOLVED_IN",
+        "fromId": "n3",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "TREATS",
+        "fromId": "n2",
+        "toId": "n0",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/configurable-bom.json
+++ b/neo4j-modeling-skill/references/configurable-bom.json
@@ -1,0 +1,80 @@
+{
+  "id": "configurable-bom",
+  "name": "Configurable Bill of Materials",
+  "description": "Models configurable product structures (150% BOM / CBOM) with assemblies, config groups, parts, and variant resolution via RESOLVED_LINK. Source: https://neo4j.com/developer/industry-use-cases/manufacturing/product-design-and-engineering/configurable-bom/",
+  "industry": "Manufacturing",
+  "tags": [
+    "BOM",
+    "CBOM",
+    "product-design",
+    "manufacturing",
+    "configuration",
+    "150-percent-BOM"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 50 },
+        "caption": "Product",
+        "labels": ["Product"],
+        "properties": {
+          "id": "string",
+          "desc": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 200, "y": 250 },
+        "caption": "Assembly",
+        "labels": ["Assembly"],
+        "properties": {
+          "id": "string",
+          "desc": "string",
+          "category": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 600, "y": 250 },
+        "caption": "ConfigGroup",
+        "labels": ["ConfigGroup"],
+        "properties": {
+          "id": "string",
+          "category": "string",
+          "options": "list",
+          "desc": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 400, "y": 450 },
+        "caption": "Part",
+        "labels": ["Part"],
+        "properties": {
+          "id": "string",
+          "desc": "string",
+          "cost": "float",
+          "weight": "float"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_PART", "fromId": "n0", "toId": "n3", "properties": { "qty": "integer" } },
+      { "id": "r1", "type": "REQUIRES", "fromId": "n0", "toId": "n1", "properties": { "qty": "integer", "note": "string" } },
+      { "id": "r2", "type": "HAS_OPTION", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r3", "type": "REQUIRES", "fromId": "n1", "toId": "n2", "properties": { "qty": "integer", "note": "string" } },
+      { "id": "r4", "type": "REQUIRES", "fromId": "n1", "toId": "n1", "properties": { "qty": "integer", "note": "string" } },
+      { "id": "r5", "type": "HAS_PART", "fromId": "n1", "toId": "n3", "properties": { "qty": "integer" } },
+      { "id": "r6", "type": "HAS_OPTION", "fromId": "n2", "toId": "n3", "properties": {} },
+      { "id": "r7", "type": "REQUIRES", "fromId": "n2", "toId": "n3", "properties": { "qty": "integer", "note": "string" } },
+      { "id": "r8", "type": "RESOLVED_LINK", "fromId": "n3", "toId": "n3", "properties": { "id_variant": "string", "rel_type": "string", "qty": "integer" } }
+    ],
+    "style": {}
+  },
+  "notes": "RESOLVED_LINK is dynamically materialised by the variant-resolution query and can appear along any edge of a resolved path. HAS_PART carries qty; REQUIRES carries qty and note; HAS_OPTION has no properties in the 150% BOM. Resolved BOM materialises RESOLVED_LINK between nodes with id_variant, rel_type, and qty."
+}

--- a/neo4j-modeling-skill/references/customer-churn.json
+++ b/neo4j-modeling-skill/references/customer-churn.json
@@ -1,0 +1,83 @@
+{
+  "id": "customer-churn",
+  "name": "Graph-Aware Finance Churn Prediction",
+  "description": "Models user/card/merchant/transaction flow for predicting silent (dormancy) churn in retail banking using GDS FastRP embeddings and Random Forest. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/customer-churn/",
+  "industry": "Financial Services",
+  "tags": [
+    "churn",
+    "retention",
+    "retail-banking",
+    "GDS",
+    "FastRP",
+    "embeddings",
+    "dormancy"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 200 },
+        "caption": "User",
+        "labels": ["User"],
+        "properties": {
+          "userId": "string",
+          "userLatitude": "float",
+          "userLongitude": "float",
+          "income": "float",
+          "debt": "float",
+          "creditScore": "integer",
+          "churned": "boolean",
+          "riskProbability": "float"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 400, "y": 200 },
+        "caption": "Card",
+        "labels": ["Card"],
+        "properties": {
+          "cardId": "string",
+          "type": "string",
+          "issuedDate": "date"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 700, "y": 200 },
+        "caption": "Transaction",
+        "labels": ["Transaction"],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 1000, "y": 200 },
+        "caption": "Merchant",
+        "labels": ["Merchant"],
+        "properties": {
+          "merchantId": "string",
+          "name": "string",
+          "category": "string",
+          "latitude": "float",
+          "longitude": "float"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "OWNS", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "PERFORMED", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "TO", "fromId": "n2", "toId": "n3", "properties": {} },
+      { "id": "r3", "type": "SHOPPED_AT", "fromId": "n0", "toId": "n3", "properties": { "weight": "integer" } }
+    ],
+    "style": {}
+  },
+  "notes": "SHOPPED_AT is a GDS-projected/aggregated relationship: User→Merchant weighted by transaction count. It simplifies the User→Card→Transaction→Merchant path for FastRP embedding and similarity analysis."
+}

--- a/neo4j-modeling-skill/references/deposit-analysis.json
+++ b/neo4j-modeling-skill/references/deposit-analysis.json
@@ -1,0 +1,97 @@
+{
+  "id": "deposit-analysis",
+  "name": "Deposit Analysis",
+  "description": "Models customer deposit behaviour using the transaction base model pattern. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/deposit-analysis/",
+  "industry": "Financial Services",
+  "tags": [
+    "retail-banking",
+    "deposits",
+    "customer-analytics"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 100
+        },
+        "caption": "Customer",
+        "labels": [
+          "Customer"
+        ],
+        "properties": {
+          "customerId": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 300
+        },
+        "caption": "Account",
+        "labels": [
+          "Account"
+        ],
+        "properties": {
+          "accountId": "string",
+          "accountNumber": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 400,
+          "y": 450
+        },
+        "caption": "Transaction",
+        "labels": [
+          "Transaction"
+        ],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "type": "string",
+          "timestamp": "datetime"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_ACCOUNT",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "PERFORMS",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "BENEFITS_TO",
+        "fromId": "n2",
+        "toId": "n1",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/drug-safety.json
+++ b/neo4j-modeling-skill/references/drug-safety.json
@@ -1,0 +1,111 @@
+{
+  "id": "drug-safety",
+  "name": "Drug Safety & Pharmacovigilance (FAERS)",
+  "description": "Pharmacovigilance data model using FDA FAERS (FDA Adverse Event Reporting System) structure. Tracks adverse drug events, drug-drug interactions, and post-marketing safety surveillance. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/medical-care/drug-safety/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "pharmacovigilance",
+    "drug-safety",
+    "FAERS",
+    "adverse-events",
+    "ADR",
+    "post-marketing-surveillance"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 300 },
+        "caption": "Case",
+        "labels": ["Case"],
+        "properties": {
+          "caseId": "string",
+          "primaryId": "string",
+          "eventDate": "date",
+          "reportDate": "date",
+          "reporterOccupation": "string",
+          "age": "integer",
+          "ageGroup": "string",
+          "sex": "string",
+          "weight": "float"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 100, "y": 100 },
+        "caption": "Outcome",
+        "labels": ["Outcome"],
+        "properties": {
+          "code": "string",
+          "description": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 45 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 400, "y": 100 },
+        "caption": "MedDraTerm",
+        "labels": ["MedDraTerm"],
+        "properties": {
+          "name": "string",
+          "meddraCode": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 700, "y": 300 },
+        "caption": "DrugCase",
+        "labels": ["DrugCase"],
+        "properties": {
+          "drugCaseId": "string",
+          "role": "string",
+          "dose": "string",
+          "route": "string",
+          "startDate": "date",
+          "endDate": "date"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 950, "y": 300 },
+        "caption": "Drug",
+        "labels": ["Drug"],
+        "properties": {
+          "name": "string",
+          "activeIngredient": "string",
+          "rxnormCode": "string",
+          "atcCode": "string",
+          "tradeNameValidated": "boolean"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 100, "y": 500 },
+        "caption": "Manufacturer",
+        "labels": ["Manufacturer"],
+        "properties": {
+          "name": "string"
+        },
+        "style": { "color": "#FCDC00", "radius": 45 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_OUTCOME", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "HAS_REACTION", "fromId": "n0", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "REPORTED_BY", "fromId": "n0", "toId": "n5", "properties": {} },
+      { "id": "r3", "type": "PRIMARY_SUSPECT_DRUG", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r4", "type": "SECONDARY_SUSPECT_DRUG", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r5", "type": "CONCOMITANT_DRUG", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r6", "type": "DRUG_NOT_ADMINISTERED", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r7", "type": "CONCERNS_DRUG", "fromId": "n3", "toId": "n4", "properties": {} },
+      { "id": "r8", "type": "INDICATION_FOR_USE", "fromId": "n3", "toId": "n2", "properties": {} },
+      { "id": "r9", "type": "INTERACTING_DRUG", "fromId": "n4", "toId": "n4", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "Case nodes also receive secondary labels (Adult, Infant, Child, Male, Female, etc) for grouping. DrugCase represents a drug instance tied to a specific case with role/dose/route. Drugs use RxNorm; adverse events use MedDRA preferred terms."
+}

--- a/neo4j-modeling-skill/references/engineering-traceability.json
+++ b/neo4j-modeling-skill/references/engineering-traceability.json
@@ -1,0 +1,134 @@
+{
+  "id": "engineering-traceability",
+  "name": "Engineering Traceability",
+  "description": "Traces customer requests through requirements, designs and test cases for full lifecycle traceability. Source: https://neo4j.com/developer/industry-use-cases/manufacturing/product-design-and-engineering/engineering-traceability/",
+  "industry": "Manufacturing",
+  "tags": [
+    "traceability",
+    "engineering",
+    "requirements",
+    "testing"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 150,
+          "y": 100
+        },
+        "caption": "CustomerRequest",
+        "labels": [
+          "CustomerRequest"
+        ],
+        "properties": {
+          "id": "string",
+          "description": "string",
+          "status": "string",
+          "source": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 450,
+          "y": 100
+        },
+        "caption": "Requirement",
+        "labels": [
+          "Requirement"
+        ],
+        "properties": {
+          "id": "string",
+          "title": "string",
+          "description": "string",
+          "status": "string",
+          "source": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 450,
+          "y": 350
+        },
+        "caption": "Design",
+        "labels": [
+          "Design"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string",
+          "description": "string",
+          "status": "string",
+          "source": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 150,
+          "y": 350
+        },
+        "caption": "TestCase",
+        "labels": [
+          "TestCase"
+        ],
+        "properties": {
+          "id": "string",
+          "title": "string",
+          "description": "string",
+          "status": "string",
+          "source": "string"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "SATISFIES",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "IMPLEMENTED_BY",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "DEPENDS_ON",
+        "fromId": "n2",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "TESTED_BY",
+        "fromId": "n2",
+        "toId": "n3",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/entity-resolution.json
+++ b/neo4j-modeling-skill/references/entity-resolution.json
@@ -1,0 +1,39 @@
+{
+  "id": "entity-resolution",
+  "name": "Entity Resolution",
+  "description": "Industry-agnostic entity resolution / record linkage model. Deduplicates Address nodes using Levenshtein similarity on address fields and geographic distance between postcode-derived coordinates, creating SIMILAR_ADDRESS self-relationships for further resolution. Source: https://neo4j.com/developer/industry-use-cases/agnostic/entity-resolution/",
+  "industry": "Industry Agnostic",
+  "tags": [
+    "entity-resolution",
+    "record-linkage",
+    "deduplication",
+    "data-quality",
+    "address-matching",
+    "KYC"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n1",
+        "position": { "x": 500, "y": 200 },
+        "caption": "Address",
+        "labels": ["Address"],
+        "properties": {
+          "RegAddressAddressLine1": "string",
+          "RegAddressAddressLine2": "string",
+          "RegAddressPostTown": "string",
+          "RegAddressPostCode": "string",
+          "FullAddress": "string",
+          "Latitude": "float",
+          "Longitude": "float"
+        },
+        "style": { "color": "#009CE0", "radius": 55 }
+      }
+    ],
+    "relationships": [
+      { "id": "r2", "type": "SIMILAR_ADDRESS", "fromId": "n1", "toId": "n1", "properties": { "line_1_sim": "float", "line_2_sim": "float", "full_address_sim": "float", "post_sim": "float", "distanceMeters": "float" } }
+    ],
+    "style": {}
+  },
+  "notes": "SIMILAR_ADDRESS is a self-loop on Address nodes created via APOC Levenshtein similarity (apoc.text.levenshteinSimilarity) across address lines and postcodes, combined with point.distance geographic comparison. Thresholds used in the reference: full_address_sim > 0.6, post_sim > 0.7."
+}

--- a/neo4j-modeling-skill/references/ev-route-planning.json
+++ b/neo4j-modeling-skill/references/ev-route-planning.json
@@ -1,0 +1,114 @@
+{
+  "id": "ev-route-planning",
+  "name": "Electric Vehicle Route Planning",
+  "description": "Models road networks with cities, charging stations and EVs for energy-aware route optimization using Cypher 25 stateful path finding. Source: https://neo4j.com/developer/industry-use-cases/manufacturing/supply-chain-management/ev-route-planning/",
+  "industry": "Manufacturing",
+  "tags": [
+    "EV",
+    "route-planning",
+    "supply-chain",
+    "logistics",
+    "Cypher-25"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 300,
+          "y": 100
+        },
+        "caption": "Geo",
+        "labels": [
+          "Geo"
+        ],
+        "properties": {
+          "name": "string",
+          "geo": "point"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 600,
+          "y": 100
+        },
+        "caption": "ChargingStation",
+        "labels": [
+          "ChargingStation",
+          "Geo"
+        ],
+        "properties": {
+          "name": "string",
+          "power_kw": "float",
+          "geo": "point"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 450,
+          "y": 350
+        },
+        "caption": "Car",
+        "labels": [
+          "Car"
+        ],
+        "properties": {
+          "id": "string",
+          "battery_capacity_kwh": "float",
+          "efficiency_kwh_per_km": "float",
+          "current_soc_percent": "float"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "ROAD",
+        "fromId": "n0",
+        "toId": "n0",
+        "properties": {
+          "distance_km": "float",
+          "speed_limit_kph": "float",
+          "hourly_expected_speed_kph": "list_of_float"
+        }
+      },
+      {
+        "id": "r1",
+        "type": "ROAD",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {
+          "distance_km": "float",
+          "speed_limit_kph": "float",
+          "hourly_expected_speed_kph": "list_of_float"
+        }
+      },
+      {
+        "id": "r2",
+        "type": "CHARGE",
+        "fromId": "n1",
+        "toId": "n1",
+        "properties": {
+          "station_id": "string",
+          "power_kw": "float",
+          "time_in_minutes": "integer"
+        }
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/fraud-event-sequence-model.json
+++ b/neo4j-modeling-skill/references/fraud-event-sequence-model.json
@@ -1,0 +1,191 @@
+{
+  "id": "fraud-event-sequence",
+  "name": "Fraud Event Sequence Model",
+  "description": "Event-oriented extension of the Transaction & Account Base Model for detecting account takeover fraud through chronological event sequences. Introduces Authentication, ChangePhone, ChangeEmail, ChangeAddress, AddExternalAccount, and Transfer event nodes linked via :NEXT chains. Source: https://neo4j.com/developer/industry-use-cases/data-models/transaction-graph/fraud-event-sequence/fraud-event-sequence-model/",
+  "industry": "Financial Services",
+  "tags": ["fraud-detection", "account-takeover", "event-sequence", "AML", "banking", "cybersecurity"],
+  "extends": "transaction-base-model",
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 50 },
+        "caption": "Customer",
+        "labels": ["Customer"],
+        "properties": {
+          "customerId": "string",
+          "firstName": "string",
+          "lastName": "string",
+          "dateOfBirth": "date"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 100, "y": 200 },
+        "caption": "Account",
+        "labels": ["Account", "Internal"],
+        "properties": {
+          "accountNumber": "string",
+          "accountType": "string",
+          "openedDate": "datetime"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": -150, "y": 200 },
+        "caption": "Session",
+        "labels": ["Session"],
+        "properties": {
+          "sessionId": "string",
+          "status": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#F44E3B", "radius": 45 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 100, "y": 400 },
+        "caption": "Authentication",
+        "labels": ["Authentication"],
+        "properties": {
+          "method": "string",
+          "status": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FE9200", "radius": 45 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 350, "y": 400 },
+        "caption": "ChangePhone",
+        "labels": ["ChangePhone"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FCDC00", "radius": 40 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 600, "y": 400 },
+        "caption": "ChangeEmail",
+        "labels": ["ChangeEmail"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#A4DD00", "radius": 40 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 850, "y": 400 },
+        "caption": "ChangeAddress",
+        "labels": ["ChangeAddress"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#68CCCA", "radius": 40 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": 600, "y": 600 },
+        "caption": "AddExternalAccount",
+        "labels": ["AddExternalAccount"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#AEA1FF", "radius": 42 }
+      },
+      {
+        "id": "n8",
+        "position": { "x": 350, "y": 600 },
+        "caption": "Transfer",
+        "labels": ["Transfer"],
+        "properties": {
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FA28FF", "radius": 42 }
+      },
+      {
+        "id": "n9",
+        "position": { "x": 350, "y": 200 },
+        "caption": "Phone",
+        "labels": ["Phone"],
+        "properties": {
+          "phoneNumber": "string",
+          "countryCode": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#73D8FF", "radius": 35 }
+      },
+      {
+        "id": "n10",
+        "position": { "x": 600, "y": 200 },
+        "caption": "Email",
+        "labels": ["Email"],
+        "properties": {
+          "address": "string",
+          "domain": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#B0BC00", "radius": 35 }
+      },
+      {
+        "id": "n11",
+        "position": { "x": 850, "y": 200 },
+        "caption": "Address",
+        "labels": ["Address"],
+        "properties": {
+          "addressLine1": "string",
+          "postTown": "string",
+          "postCode": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#16A5A5", "radius": 35 }
+      },
+      {
+        "id": "n12",
+        "position": { "x": 850, "y": 600 },
+        "caption": "Transaction",
+        "labels": ["Transaction"],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime",
+          "type": "string"
+        },
+        "style": { "color": "#D33115", "radius": 45 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_ACCOUNT", "fromId": "n0", "toId": "n1", "properties": { "role": "string", "since": "datetime" } },
+      { "id": "r1", "type": "CONNECTS", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r2", "type": "HAS_AUTHENTICATION", "fromId": "n2", "toId": "n3", "properties": {} },
+      { "id": "r3", "type": "HAS_CHANGE_PHONE", "fromId": "n2", "toId": "n4", "properties": {} },
+      { "id": "r4", "type": "HAS_CHANGE_EMAIL", "fromId": "n2", "toId": "n5", "properties": {} },
+      { "id": "r5", "type": "HAS_CHANGE_ADDRESS", "fromId": "n2", "toId": "n6", "properties": {} },
+      { "id": "r6", "type": "HAS_ADD_EXTERNAL_ACCOUNT", "fromId": "n2", "toId": "n7", "properties": {} },
+      { "id": "r7", "type": "HAS_TRANSFER", "fromId": "n2", "toId": "n8", "properties": {} },
+      { "id": "r8", "type": "NEXT", "fromId": "n3", "toId": "n4", "properties": {} },
+      { "id": "r9", "type": "NEXT", "fromId": "n4", "toId": "n5", "properties": {} },
+      { "id": "r10", "type": "NEXT", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r11", "type": "NEXT", "fromId": "n6", "toId": "n7", "properties": {} },
+      { "id": "r12", "type": "NEXT", "fromId": "n7", "toId": "n8", "properties": {} },
+      { "id": "r13", "type": "OLD_PHONE", "fromId": "n4", "toId": "n9", "properties": {} },
+      { "id": "r14", "type": "NEW_PHONE", "fromId": "n4", "toId": "n9", "properties": {} },
+      { "id": "r15", "type": "OLD_EMAIL", "fromId": "n5", "toId": "n10", "properties": {} },
+      { "id": "r16", "type": "NEW_EMAIL", "fromId": "n5", "toId": "n10", "properties": {} },
+      { "id": "r17", "type": "OLD_ADDRESS", "fromId": "n6", "toId": "n11", "properties": {} },
+      { "id": "r18", "type": "NEW_ADDRESS", "fromId": "n6", "toId": "n11", "properties": {} },
+      { "id": "r19", "type": "ADD_ACCOUNT", "fromId": "n7", "toId": "n1", "properties": {} },
+      { "id": "r20", "type": "HAS_TRANSACTION", "fromId": "n8", "toId": "n12", "properties": {} },
+      { "id": "r21", "type": "PERFORMS", "fromId": "n1", "toId": "n12", "properties": {} },
+      { "id": "r22", "type": "BENEFITS_TO", "fromId": "n12", "toId": "n1", "properties": {} },
+      { "id": "r23", "type": "HAS_PHONE", "fromId": "n0", "toId": "n9", "properties": { "since": "datetime" } },
+      { "id": "r24", "type": "HAS_EMAIL", "fromId": "n0", "toId": "n10", "properties": { "since": "datetime" } },
+      { "id": "r25", "type": "HAS_ADDRESS", "fromId": "n0", "toId": "n11", "properties": { "addedAt": "datetime", "isCurrent": "boolean" } }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/iam-effective-access.json
+++ b/neo4j-modeling-skill/references/iam-effective-access.json
@@ -1,0 +1,85 @@
+{
+  "id": "iam-effective-access",
+  "name": "Identity & Access Management (Effective Access Analysis)",
+  "description": "Industry-agnostic IAM model for effective access analysis across identities, nested groups, roles, entitlements and resources. Computes effective access dynamically through graph traversal rather than pre-computed ACLs. Source: https://neo4j.com/developer/industry-use-cases/agnostic/iam/access-and-authorization/effective-access-analysis/",
+  "industry": "Industry Agnostic",
+  "tags": [
+    "IAM",
+    "access-control",
+    "RBAC",
+    "effective-access",
+    "authorization",
+    "audit",
+    "compliance"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 200 },
+        "caption": "Identity",
+        "labels": ["Identity"],
+        "properties": {
+          "id": "string",
+          "type": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 400, "y": 200 },
+        "caption": "Group",
+        "labels": ["Group"],
+        "properties": {
+          "id": "string",
+          "name": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 700, "y": 200 },
+        "caption": "Role",
+        "labels": ["Role"],
+        "properties": {
+          "id": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 1000, "y": 200 },
+        "caption": "Entitlement",
+        "labels": ["Entitlement"],
+        "properties": {
+          "id": "string",
+          "action": "string"
+        },
+        "style": { "color": "#7B64FF", "radius": 45 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 1000, "y": 400 },
+        "caption": "Resource",
+        "labels": ["Resource"],
+        "properties": {
+          "id": "string",
+          "type": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "MEMBER_OF", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "MEMBER_OF", "fromId": "n1", "toId": "n1", "properties": {} },
+      { "id": "r2", "type": "GRANTS_ROLE", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r3", "type": "ASSIGNED_ROLE", "fromId": "n0", "toId": "n2", "properties": {} },
+      { "id": "r4", "type": "GRANTS", "fromId": "n2", "toId": "n3", "properties": {} },
+      { "id": "r5", "type": "APPLIES_TO", "fromId": "n3", "toId": "n4", "properties": {} },
+      { "id": "r6", "type": "PARENT_OF", "fromId": "n4", "toId": "n4", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "Effective-access traversal: (Identity)-[:MEMBER_OF]->(Group), (Group)-[:MEMBER_OF]->(Group) for nested groups, (Group)-[:GRANTS_ROLE]->(Role), (Identity)-[:ASSIGNED_ROLE]->(Role) for direct role assignment exceptions, (Role)-[:GRANTS]->(Entitlement), (Entitlement)-[:APPLIES_TO]->(Resource). Resource-[:PARENT_OF]->Resource captures folder/hierarchy. Example query: MATCH p=(i:Identity {id:'bob'})-->{1,50}(e:Entitlement)-[:APPLIES_TO]->(r:Resource) RETURN r.id, e.action."
+}

--- a/neo4j-modeling-skill/references/it-service-graph.json
+++ b/neo4j-modeling-skill/references/it-service-graph.json
@@ -1,0 +1,114 @@
+{
+  "id": "it-service-graph",
+  "name": "IT Service Graph",
+  "description": "Industry-agnostic CMDB-style IT service graph modeling infrastructure (datacenters, sections/rooms, racks, servers), software, services, and customers. Enables service chain, root-cause, and impact analysis across the IT landscape. Source: https://neo4j.com/developer/industry-use-cases/agnostic/it-service-graph/it-service-graph/",
+  "industry": "Industry Agnostic",
+  "tags": [
+    "CMDB",
+    "IT-operations",
+    "service-chain",
+    "impact-analysis",
+    "root-cause",
+    "dependencies"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 100 },
+        "caption": "Datacenter",
+        "labels": ["Datacenter"],
+        "properties": {
+          "dcName": "string",
+          "dcCity": "string",
+          "dcGeoLocation": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 100, "y": 280 },
+        "caption": "Section",
+        "labels": ["Section", "Room"],
+        "properties": {
+          "name": "string",
+          "geoLocation": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 45 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 100, "y": 460 },
+        "caption": "Rack",
+        "labels": ["Rack"],
+        "properties": {
+          "rackName": "string",
+          "geoLocation": "string",
+          "freeUnits": "integer"
+        },
+        "style": { "color": "#FA28FF", "radius": 45 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 400, "y": 460 },
+        "caption": "Server",
+        "labels": ["Server", "VM", "Container"],
+        "properties": {
+          "assetNumber": "string",
+          "name": "string",
+          "firstSeen": "date",
+          "leaseEnd": "date"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 700, "y": 460 },
+        "caption": "Software",
+        "labels": ["Software"],
+        "properties": {
+          "swName": "string",
+          "swVersion": "string",
+          "lastUpdated": "date",
+          "swVendor": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 700, "y": 280 },
+        "caption": "Service",
+        "labels": ["Service"],
+        "properties": {
+          "serviceName": "string",
+          "serviceOwner": "string"
+        },
+        "style": { "color": "#FCDC00", "radius": 50 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 700, "y": 100 },
+        "caption": "Customer",
+        "labels": ["Customer"],
+        "properties": {
+          "customerName": "string",
+          "customerDept": "string",
+          "customerImportance": "integer"
+        },
+        "style": { "color": "#A4DD00", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "IN_SECTION", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "IN_RACK", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "LOCATED_IN", "fromId": "n3", "toId": "n0", "properties": {} },
+      { "id": "r3", "type": "INSTALLED_ON", "fromId": "n4", "toId": "n3", "properties": {} },
+      { "id": "r4", "type": "DELIVERS", "fromId": "n4", "toId": "n5", "properties": {} },
+      { "id": "r5", "type": "RUNS", "fromId": "n3", "toId": "n5", "properties": { "since": "date", "serviceSLA": "integer" } },
+      { "id": "r6", "type": "USED_BY", "fromId": "n5", "toId": "n6", "properties": { "since": "date" } },
+      { "id": "r7", "type": "IN_ROOM", "fromId": "n1", "toId": "n1", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "Full service chain template for impact analysis: (Rack)<-[:IN_RACK]-(Section)<-[:IN_SECTION]-(Datacenter)<-[:LOCATED_IN]-(Server)<-[:INSTALLED_ON]-(Software)-[:DELIVERS]->(Service)-[:USED_BY]->(Customer). Server additionally RUNS Service directly. Section/Room can have an IN_ROOM self-relationship to express room hierarchy within a section."
+}

--- a/neo4j-modeling-skill/references/model-index.json
+++ b/neo4j-modeling-skill/references/model-index.json
@@ -1,0 +1,497 @@
+{
+  "version": "2.0",
+  "source": "https://neo4j.com/developer/industry-use-cases/",
+  "lastUpdated": "2026-04-23",
+  "industries": [
+    "Financial Services",
+    "Insurance",
+    "Healthcare & Life Sciences",
+    "Manufacturing",
+    "Cybersecurity",
+    "Industry Agnostic"
+  ],
+  "models": [
+    {
+      "id": "transaction-base-model",
+      "name": "Transaction & Account Base Model",
+      "file": "transaction-base-model.json",
+      "industry": "Financial Services",
+      "description": "Standardised banking data model for transactions, accounts, customers, KYC, sessions, and fraud investigations.",
+      "nodeCount": 19,
+      "relationshipCount": 24,
+      "tags": [
+        "banking",
+        "transactions",
+        "fraud",
+        "KYC",
+        "AML"
+      ]
+    },
+    {
+      "id": "fraud-event-sequence",
+      "name": "Fraud Event Sequence Model",
+      "file": "fraud-event-sequence-model.json",
+      "industry": "Financial Services",
+      "description": "Event-oriented extension for detecting account takeover fraud through chronological event chains.",
+      "nodeCount": 13,
+      "relationshipCount": 26,
+      "tags": [
+        "fraud-detection",
+        "account-takeover",
+        "event-sequence"
+      ]
+    },
+    {
+      "id": "regulatory-dependency-mapping",
+      "name": "Regulatory Dependency Mapping",
+      "file": "regulatory-dependency-mapping.json",
+      "industry": "Financial Services",
+      "description": "Maps regulatory dependencies between standards and sections.",
+      "nodeCount": 2,
+      "relationshipCount": 3,
+      "tags": [
+        "regulatory",
+        "compliance",
+        "investment-banking"
+      ]
+    },
+    {
+      "id": "mutual-fund-dependency",
+      "name": "Mutual Fund Dependency Analytics",
+      "file": "mutual-fund-dependency.json",
+      "industry": "Financial Services",
+      "description": "Analyses investment dependencies between funds and underlying stocks.",
+      "nodeCount": 3,
+      "relationshipCount": 2,
+      "tags": [
+        "investment-banking",
+        "mutual-funds",
+        "portfolio"
+      ]
+    },
+    {
+      "id": "deposit-analysis",
+      "name": "Deposit Analysis",
+      "file": "deposit-analysis.json",
+      "industry": "Financial Services",
+      "description": "Models customer deposit behaviour using the transaction base model pattern.",
+      "nodeCount": 3,
+      "relationshipCount": 3,
+      "tags": [
+        "retail-banking",
+        "deposits",
+        "customer-analytics"
+      ]
+    },
+    {
+      "id": "account-takeover-fraud",
+      "name": "Account Takeover Fraud",
+      "file": "account-takeover-fraud.json",
+      "industry": "Financial Services",
+      "description": "Detects ATO fraud using the transaction base model with event-based fraud detection. References the Fraud Event Sequence Data Model.",
+      "nodeCount": 19,
+      "relationshipCount": 35,
+      "tags": [
+        "fraud",
+        "account-takeover",
+        "retail-banking"
+      ]
+    },
+    {
+      "id": "automated-facial-recognition",
+      "name": "Automated Facial Recognition",
+      "file": "automated-facial-recognition.json",
+      "industry": "Financial Services",
+      "description": "Facial biometric matching using vector embeddings on Face nodes. Uses cosine similarity for identity verification.",
+      "nodeCount": 1,
+      "relationshipCount": 0,
+      "tags": [
+        "facial-recognition",
+        "KYC",
+        "biometrics",
+        "vector-search"
+      ]
+    },
+    {
+      "id": "synthetic-identity-fraud",
+      "name": "Synthetic Identity Fraud",
+      "file": "synthetic-identity-fraud.json",
+      "industry": "Financial Services",
+      "description": "Detects synthetic identities via shared PII (email, phone, passport) between customers. Uses LINKED relationships for GDS community detection.",
+      "nodeCount": 4,
+      "relationshipCount": 4,
+      "tags": [
+        "fraud",
+        "synthetic-identity",
+        "KYC",
+        "GDS"
+      ]
+    },
+    {
+      "id": "transaction-fraud-ring",
+      "name": "Transaction Fraud Ring",
+      "file": "transaction-fraud-ring.json",
+      "industry": "Financial Services",
+      "description": "Detects circular transaction flows between accounts. Uses Account and Transaction nodes with PERFORMS/BENEFITS_TO ring pattern.",
+      "nodeCount": 2,
+      "relationshipCount": 2,
+      "tags": [
+        "fraud-ring",
+        "transaction-fraud",
+        "APP-fraud"
+      ]
+    },
+    {
+      "id": "transaction-monitoring",
+      "name": "Transaction Monitoring",
+      "file": "transaction-monitoring.json",
+      "industry": "Financial Services",
+      "description": "AML transaction monitoring linking accounts, transactions, counterparties and jurisdictions.",
+      "nodeCount": 8,
+      "relationshipCount": 10,
+      "tags": [
+        "AML",
+        "transaction-monitoring",
+        "compliance"
+      ]
+    },
+    {
+      "id": "transaction-fraud-detection",
+      "name": "Transaction Fraud Detection (IEEE-CIS)",
+      "file": "transaction-fraud-detection.json",
+      "industry": "Financial Services",
+      "description": "Graph-based fraud detection with Transaction, Card, Device, Email, Address, Identity nodes for ML feature engineering.",
+      "nodeCount": 6,
+      "relationshipCount": 5,
+      "tags": [
+        "fraud-detection",
+        "IEEE-CIS",
+        "machine-learning",
+        "GDS"
+      ]
+    },
+    {
+      "id": "customer-churn",
+      "name": "Graph-Aware Finance Churn Prediction",
+      "file": "customer-churn.json",
+      "industry": "Financial Services",
+      "description": "Predicts silent (dormancy) churn in retail banking using User/Card/Transaction/Merchant graph and GDS FastRP embeddings with Random Forest.",
+      "nodeCount": 4,
+      "relationshipCount": 4,
+      "tags": [
+        "churn",
+        "retention",
+        "retail-banking",
+        "GDS",
+        "FastRP",
+        "embeddings"
+      ]
+    },
+    {
+      "id": "ubo-company-ownership",
+      "name": "Ultimate Beneficial Owner (UBO) & Company Ownership",
+      "file": "ubo-company-ownership.json",
+      "industry": "Financial Services",
+      "description": "Models corporate ownership hierarchies across individuals, companies, and legal entities for UBO identification and AML/KYC compliance (6AMLD).",
+      "nodeCount": 5,
+      "relationshipCount": 5,
+      "tags": [
+        "UBO",
+        "beneficial-ownership",
+        "KYC",
+        "AML",
+        "6AMLD",
+        "corporate-structure"
+      ]
+    },
+    {
+      "id": "claims-fraud",
+      "name": "Insurance Claims Fraud",
+      "file": "claims-fraud.json",
+      "industry": "Insurance",
+      "description": "Detects claims fraud via Claimant, Claim, MedicalProfessional, Vehicle connections.",
+      "nodeCount": 4,
+      "relationshipCount": 5,
+      "tags": [
+        "insurance",
+        "claims-fraud",
+        "crash-for-cash"
+      ]
+    },
+    {
+      "id": "quote-fraud",
+      "name": "Insurance Quote Fraud",
+      "file": "quote-fraud.json",
+      "industry": "Insurance",
+      "description": "Detects quote manipulation via linked list of Quote nodes tracking sequential changes with time deltas.",
+      "nodeCount": 1,
+      "relationshipCount": 1,
+      "tags": [
+        "insurance",
+        "quote-fraud",
+        "ghost-broking"
+      ]
+    },
+    {
+      "id": "patient-journey",
+      "name": "Patient Journey",
+      "file": "patient-journey.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Tracks patient healthcare journeys through encounters, observations, diagnoses, prescriptions, and providers.",
+      "nodeCount": 8,
+      "relationshipCount": 8,
+      "tags": [
+        "healthcare",
+        "patient-journey",
+        "clinical",
+        "OMOP"
+      ]
+    },
+    {
+      "id": "patent-intelligence",
+      "name": "Patent Intelligence",
+      "file": "patent-intelligence.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Maps pharmaceutical patent landscapes with owners, targets, diseases and drug classes.",
+      "nodeCount": 12,
+      "relationshipCount": 13,
+      "tags": [
+        "patent",
+        "competitive-intelligence",
+        "pharma"
+      ]
+    },
+    {
+      "id": "publication-intelligence",
+      "name": "Publication Intelligence",
+      "file": "publication-intelligence.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Analyses scientific publication networks with papers, authors, institutions, journals and topics.",
+      "nodeCount": 10,
+      "relationshipCount": 13,
+      "tags": [
+        "publication",
+        "research",
+        "competitive-intelligence",
+        "KOL"
+      ]
+    },
+    {
+      "id": "pipeline-intelligence",
+      "name": "Pharma Pipeline Intelligence",
+      "file": "pipeline-intelligence.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Models pharma R&D pipeline \u2014 companies, drugs, targets, diseases, clinical trials, development phases \u2014 for competitive landscape analysis.",
+      "nodeCount": 7,
+      "relationshipCount": 11,
+      "tags": [
+        "pipeline",
+        "pharma",
+        "competitive-intelligence",
+        "clinical-trials",
+        "R&D"
+      ]
+    },
+    {
+      "id": "drug-safety",
+      "name": "Drug Safety & Pharmacovigilance (FAERS)",
+      "file": "drug-safety.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Pharmacovigilance model using FDA FAERS structure. Tracks adverse drug events, drug-drug interactions, and post-marketing safety surveillance.",
+      "nodeCount": 6,
+      "relationshipCount": 10,
+      "tags": [
+        "pharmacovigilance",
+        "drug-safety",
+        "FAERS",
+        "adverse-events",
+        "ADR"
+      ]
+    },
+    {
+      "id": "single-omics",
+      "name": "Single-omics Data Integration",
+      "file": "single-omics.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Integrates single-omics data with genes, proteins, pathways and diseases.",
+      "nodeCount": 10,
+      "relationshipCount": 14,
+      "tags": [
+        "omics",
+        "genomics",
+        "proteomics",
+        "drug-discovery"
+      ]
+    },
+    {
+      "id": "multi-omics",
+      "name": "Multi-omics Data Integration",
+      "file": "multi-omics.json",
+      "industry": "Healthcare & Life Sciences",
+      "description": "Integrates multiple omics layers (genomics, transcriptomics, proteomics, metabolomics) into a unified graph.",
+      "nodeCount": 12,
+      "relationshipCount": 19,
+      "tags": [
+        "multi-omics",
+        "systems-biology",
+        "metabolomics"
+      ]
+    },
+    {
+      "id": "ev-route-planning",
+      "name": "Electric Vehicle Route Planning",
+      "file": "ev-route-planning.json",
+      "industry": "Manufacturing",
+      "description": "Models road networks with cities, charging stations and EVs for energy-aware route optimization using Cypher 25 stateful path finding.",
+      "nodeCount": 3,
+      "relationshipCount": 3,
+      "tags": [
+        "EV",
+        "route-planning",
+        "supply-chain",
+        "logistics"
+      ]
+    },
+    {
+      "id": "configurable-bom",
+      "name": "Configurable Bill of Materials",
+      "file": "configurable-bom.json",
+      "industry": "Manufacturing",
+      "description": "Models configurable product structures (150% BOM / CBOM) with config groups, parts, and variant resolution via RESOLVED_LINK.",
+      "nodeCount": 4,
+      "relationshipCount": 9,
+      "tags": [
+        "BOM",
+        "CBOM",
+        "product-design",
+        "manufacturing",
+        "configuration"
+      ]
+    },
+    {
+      "id": "engineering-traceability",
+      "name": "Engineering Traceability",
+      "file": "engineering-traceability.json",
+      "industry": "Manufacturing",
+      "description": "Traces customer requests through requirements, designs and test cases for full lifecycle traceability.",
+      "nodeCount": 4,
+      "relationshipCount": 4,
+      "tags": [
+        "traceability",
+        "engineering",
+        "requirements",
+        "testing"
+      ]
+    },
+    {
+      "id": "process-monitoring-cpa",
+      "name": "Process Monitoring & Critical Path Analysis",
+      "file": "process-monitoring-cpa.json",
+      "industry": "Manufacturing",
+      "description": "Models manufacturing processes with machines, jobs, dependencies and queue management for CPA.",
+      "nodeCount": 3,
+      "relationshipCount": 6,
+      "tags": [
+        "process-monitoring",
+        "critical-path",
+        "production",
+        "scheduling"
+      ]
+    },
+    {
+      "id": "vulnerability-prioritization",
+      "name": "Vulnerability Prioritization & Exposure Management",
+      "file": "vulnerability-prioritization.json",
+      "industry": "Cybersecurity",
+      "description": "VPEM model connecting code to cloud: compute instances, applications, libraries/SBOMs, CVEs, identities, IAM policies and cloud services. Includes CISA KEV threat intelligence.",
+      "nodeCount": 8,
+      "relationshipCount": 7,
+      "tags": [
+        "vulnerability",
+        "CVE",
+        "VPEM",
+        "exposure-management",
+        "IAM",
+        "CISA-KEV"
+      ]
+    },
+    {
+      "id": "attack-path-analysis",
+      "name": "Attack Path Analysis",
+      "file": "attack-path-analysis.json",
+      "industry": "Cybersecurity",
+      "description": "Extends the VPEM model with CAN_REACH for lateral movement simulation. Maps kill chains from initial foothold to crown jewel assets.",
+      "nodeCount": 6,
+      "relationshipCount": 6,
+      "tags": [
+        "attack-path",
+        "lateral-movement",
+        "penetration-testing"
+      ]
+    },
+    {
+      "id": "software-supply-chain-security",
+      "name": "Software Supply Chain Security (SBOM)",
+      "file": "software-supply-chain-security.json",
+      "industry": "Cybersecurity",
+      "description": "Models software bill of materials connecting applications to libraries, vulnerabilities, and the CISA KEV catalog for supply chain risk analysis.",
+      "nodeCount": 5,
+      "relationshipCount": 5,
+      "tags": [
+        "SBOM",
+        "supply-chain",
+        "dependencies",
+        "software-security"
+      ]
+    },
+    {
+      "id": "entity-resolution",
+      "name": "Entity Resolution",
+      "file": "entity-resolution.json",
+      "industry": "Industry Agnostic",
+      "description": "Industry-agnostic entity resolution / record linkage model. Deduplicates Addresses linked to Companies using Levenshtein similarity and geographic distance.",
+      "nodeCount": 1,
+      "relationshipCount": 1,
+      "tags": [
+        "entity-resolution",
+        "record-linkage",
+        "deduplication",
+        "data-quality",
+        "KYC"
+      ]
+    },
+    {
+      "id": "it-service-graph",
+      "name": "IT Service Graph",
+      "file": "it-service-graph.json",
+      "industry": "Industry Agnostic",
+      "description": "Industry-agnostic CMDB-style IT service graph modeling infrastructure, software, services, and customers. Enables root-cause, impact, and revenue-at-risk analysis.",
+      "nodeCount": 7,
+      "relationshipCount": 8,
+      "tags": [
+        "CMDB",
+        "IT-operations",
+        "service-chain",
+        "impact-analysis",
+        "dependencies"
+      ]
+    },
+    {
+      "id": "iam-effective-access",
+      "name": "Identity & Access Management (Effective Access Analysis)",
+      "file": "iam-effective-access.json",
+      "industry": "Industry Agnostic",
+      "description": "IAM model for effective access analysis across identities, nested groups, roles, entitlements and resources. Computes effective access dynamically through graph traversal.",
+      "nodeCount": 5,
+      "relationshipCount": 7,
+      "tags": [
+        "IAM",
+        "access-control",
+        "RBAC",
+        "effective-access",
+        "authorization",
+        "audit"
+      ]
+    }
+  ]
+}

--- a/neo4j-modeling-skill/references/modeling-patterns.md
+++ b/neo4j-modeling-skill/references/modeling-patterns.md
@@ -1,0 +1,52 @@
+# Modeling Patterns
+
+## Time-Series Bucket Pattern
+
+Use when a relationship accumulates millions of edges per node (e.g., page views, events).
+
+```cypher
+// Instead of: (:User)-[:VIEWED]->(:Page) (millions of rels per user)
+// Bucket by hour:
+(u:User)-[:VIEWED_IN]->(b:ViewBucket {userId: u.id, hour: '2025-04-28T14'})-[:VIEWED]->(p:Page)
+
+// Query last hour's views without traversing full history:
+MATCH (u:User {id: $uid})-[:VIEWED_IN]->(b:ViewBucket {hour: $hour})-[:VIEWED]->(p)
+RETURN p.url
+```
+
+## Versioning Pattern
+
+Track history of changes to an entity by chaining version nodes.
+
+```cypher
+(:Product)-[:CURRENT_VERSION]->(v:ProductVersion {version: "2.1", data: {...}})
+(v)-[:PREVIOUS]->(:ProductVersion {version: "2.0", data: {...}})
+```
+
+## Multi-Tenancy Pattern
+
+Isolate tenant data with a tenant root node. All tenant-scoped nodes connect to it.
+
+```cypher
+(:Tenant {id: "acme-corp"})-[:OWNS]->(:User)-[:CREATED]->(:Order)
+```
+
+Query scoped by tenant: `MATCH (t:Tenant {id: $tenantId})-[:OWNS]->(u:User) ...`
+
+## Linked List Pattern
+
+Ordered sequences without array properties. Each node points to next.
+
+```cypher
+(:Step {name: "Login"})-[:NEXT]->(:Step {name: "2FA"})-[:NEXT]->(:Step {name: "Dashboard"})
+```
+
+## Access Control Pattern
+
+Row-level security via label prefix. Application code filters out `Sec*` labels.
+
+```cypher
+(:Document:SecConfidential)-[:AUTHORED_BY]->(:Person)
+```
+
+Security labels used for access control should start with a common prefix (e.g. `Sec`) so application code can reliably filter them out of the domain schema.

--- a/neo4j-modeling-skill/references/multi-omics.json
+++ b/neo4j-modeling-skill/references/multi-omics.json
@@ -1,0 +1,176 @@
+{
+  "id": "multi-omics",
+  "name": "Multi-omics Data Integration",
+  "description": "Extends the single-omics model to integrate multiple omics layers (transcriptomics, proteomics, metabolomics) with ontologies (GO, EFO, MONDO, HPO). Adds Molecule (metabolites) and EFO (phenotype) nodes, and extends experimental measurements to proteins and molecules. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/research-development/multi-omics/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "multi-omics",
+    "transcriptomics",
+    "proteomics",
+    "metabolomics",
+    "systems-biology",
+    "research"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 300 },
+        "caption": "Project",
+        "labels": ["Project"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 50 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 300, "y": 300 },
+        "caption": "Sample",
+        "labels": ["Sample"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 300, "y": 150 },
+        "caption": "Tissue",
+        "labels": ["Tissue"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 45 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 500, "y": 300 },
+        "caption": "Experiment",
+        "labels": ["Experiment"],
+        "properties": {
+          "sid": "string",
+          "type": "string"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 400, "y": 500 },
+        "caption": "Comparison",
+        "labels": ["Comparison"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 700, "y": 300 },
+        "caption": "Gene",
+        "labels": ["Gene"],
+        "properties": {
+          "sid": "string",
+          "source": "string",
+          "symbol": "string"
+        },
+        "style": { "color": "#FCDC00", "radius": 50 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 700, "y": 150 },
+        "caption": "ID",
+        "labels": ["ID"],
+        "properties": {
+          "sid": "string",
+          "source": "string"
+        },
+        "style": { "color": "#A4DD00", "radius": 40 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": 900, "y": 300 },
+        "caption": "Protein",
+        "labels": ["Protein"],
+        "properties": {
+          "sid": "string",
+          "name": "string",
+          "uniprotId": "string"
+        },
+        "style": { "color": "#68CCCA", "radius": 45 }
+      },
+      {
+        "id": "n8",
+        "position": { "x": 900, "y": 150 },
+        "caption": "GO",
+        "labels": ["GO"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#DBDF00", "radius": 40 }
+      },
+      {
+        "id": "n9",
+        "position": { "x": 700, "y": 500 },
+        "caption": "Disease",
+        "labels": ["Disease"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FF6B6B", "radius": 45 }
+      },
+      {
+        "id": "n10",
+        "position": { "x": 1100, "y": 300 },
+        "caption": "Molecule",
+        "labels": ["Molecule"],
+        "properties": {
+          "sid": "string",
+          "name": "string",
+          "formula": "string"
+        },
+        "style": { "color": "#B0BC00", "radius": 45 }
+      },
+      {
+        "id": "n11",
+        "position": { "x": 300, "y": 500 },
+        "caption": "EFO",
+        "labels": ["EFO"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#AEA1FF", "radius": 40 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_SAMPLE", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "TAKEN_FROM", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "HAS_EXPERIMENT", "fromId": "n1", "toId": "n3", "properties": {} },
+      { "id": "r3", "type": "HAS_PHENOTYPE", "fromId": "n1", "toId": "n11", "properties": {} },
+      { "id": "r4", "type": "COMPARES", "fromId": "n4", "toId": "n3", "properties": {} },
+      { "id": "r5", "type": "INCLUDES_CONTROL", "fromId": "n4", "toId": "n1", "properties": {} },
+      { "id": "r6", "type": "INCLUDES_CASE", "fromId": "n4", "toId": "n1", "properties": {} },
+      { "id": "r7", "type": "STUDIES_DISEASE", "fromId": "n4", "toId": "n9", "properties": {} },
+      { "id": "r8", "type": "FOUND_DIFFERENTIAL", "fromId": "n4", "toId": "n5", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string", "significance": "string" } },
+      { "id": "r9", "type": "FOUND_DIFFERENTIAL", "fromId": "n4", "toId": "n7", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string", "significance": "string" } },
+      { "id": "r10", "type": "FOUND_DIFFERENTIAL", "fromId": "n4", "toId": "n10", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string", "significance": "string" } },
+      { "id": "r11", "type": "HAS_VALUE", "fromId": "n3", "toId": "n5", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string" } },
+      { "id": "r12", "type": "HAS_VALUE", "fromId": "n3", "toId": "n7", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string" } },
+      { "id": "r13", "type": "HAS_VALUE", "fromId": "n3", "toId": "n10", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string" } },
+      { "id": "r14", "type": "MAPPED", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r15", "type": "CODES", "fromId": "n5", "toId": "n7", "properties": {} },
+      { "id": "r16", "type": "ASSOCIATED_WITH", "fromId": "n7", "toId": "n8", "properties": {} },
+      { "id": "r17", "type": "INTERACTS_WITH", "fromId": "n7", "toId": "n7", "properties": { "score": "float" } },
+      { "id": "r18", "type": "RELATED_TO", "fromId": "n5", "toId": "n9", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "Multi-omics extends the single-omics model with proteomics and metabolomics layers. New Molecule node captures metabolites; new EFO node captures experimental factor/phenotype ontology terms. HAS_VALUE and FOUND_DIFFERENTIAL extend from Gene to Protein and Molecule to represent measurements across all omics layers."
+}

--- a/neo4j-modeling-skill/references/mutual-fund-dependency.json
+++ b/neo4j-modeling-skill/references/mutual-fund-dependency.json
@@ -1,0 +1,89 @@
+{
+  "id": "mutual-fund-dependency",
+  "name": "Mutual Fund Dependency Analytics",
+  "description": "Analyses investment dependencies between funds and underlying stocks. Source: https://neo4j.com/developer/industry-use-cases/finserv/investment-banking/mutual-fund-dependency/",
+  "industry": "Financial Services",
+  "tags": [
+    "investment-banking",
+    "mutual-funds",
+    "portfolio"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 150,
+          "y": 200
+        },
+        "caption": "Fund",
+        "labels": [
+          "Fund"
+        ],
+        "properties": {
+          "name": "string",
+          "isin": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 400,
+          "y": 200
+        },
+        "caption": "Holdings",
+        "labels": [
+          "Holdings"
+        ],
+        "properties": {},
+        "style": {
+          "color": "#009CE0",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 650,
+          "y": 200
+        },
+        "caption": "Stock",
+        "labels": [
+          "Stock"
+        ],
+        "properties": {
+          "name": "string",
+          "symbol": "string",
+          "isin": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 55
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HOLDINGS",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "INVESTED_IN",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {
+          "pct": "float"
+        }
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/patent-intelligence.json
+++ b/neo4j-modeling-skill/references/patent-intelligence.json
@@ -1,0 +1,334 @@
+{
+  "id": "patent-intelligence",
+  "name": "Patent Intelligence",
+  "description": "Maps pharmaceutical patent landscapes with owners, applicants, inventors, claims, families, oppositions and citations. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/competitive-intelligence/patent-intelligence/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "patent",
+    "competitive-intelligence",
+    "pharma"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 300
+        },
+        "caption": "Patent",
+        "labels": [
+          "Patent"
+        ],
+        "properties": {
+          "id": "string",
+          "title": "string",
+          "filingDate": "date"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 300
+        },
+        "caption": "Owner",
+        "labels": [
+          "Owner"
+        ],
+        "properties": {
+          "name": "string",
+          "country": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 150,
+          "y": 180
+        },
+        "caption": "Inventor",
+        "labels": [
+          "Inventor"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 150,
+          "y": 420
+        },
+        "caption": "Applicant",
+        "labels": [
+          "Applicant"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 400,
+          "y": 100
+        },
+        "caption": "Publication",
+        "labels": [
+          "Publication"
+        ],
+        "properties": {
+          "id": "string",
+          "title": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 550,
+          "y": 160
+        },
+        "caption": "Description",
+        "labels": [
+          "Description"
+        ],
+        "properties": {
+          "text": "string"
+        },
+        "style": {
+          "color": "#FCDC00",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n6",
+        "position": {
+          "x": 700,
+          "y": 220
+        },
+        "caption": "Claim",
+        "labels": [
+          "Claim"
+        ],
+        "properties": {
+          "id": "string",
+          "text": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n7",
+        "position": {
+          "x": 650,
+          "y": 400
+        },
+        "caption": "Family",
+        "labels": [
+          "Family"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#68CCCA",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n8",
+        "position": {
+          "x": 850,
+          "y": 400
+        },
+        "caption": "Superfamily",
+        "labels": [
+          "Superfamily"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#DBDF00",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n9",
+        "position": {
+          "x": 550,
+          "y": 500
+        },
+        "caption": "Opposition",
+        "labels": [
+          "Opposition"
+        ],
+        "properties": {
+          "id": "string",
+          "date": "date"
+        },
+        "style": {
+          "color": "#FF6B6B",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n10",
+        "position": {
+          "x": 750,
+          "y": 550
+        },
+        "caption": "Opponent",
+        "labels": [
+          "Opponent"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#B0BC00",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n11",
+        "position": {
+          "x": 400,
+          "y": 550
+        },
+        "caption": "Priority",
+        "labels": [
+          "Priority"
+        ],
+        "properties": {
+          "id": "string",
+          "date": "date"
+        },
+        "style": {
+          "color": "#AEA1FF",
+          "radius": 42
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_OWNER",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "HAS_INVENTOR",
+        "fromId": "n0",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "HAS_APPLICANT",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "CITES",
+        "fromId": "n0",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "HAS_DESCRIPTION",
+        "fromId": "n0",
+        "toId": "n5",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "HAS_CLAIM",
+        "fromId": "n0",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r6",
+        "type": "HAS_SUBCLAIM",
+        "fromId": "n6",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r7",
+        "type": "NEXT",
+        "fromId": "n6",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r8",
+        "type": "BELONGS_TO",
+        "fromId": "n0",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r9",
+        "type": "PART_OF",
+        "fromId": "n7",
+        "toId": "n8",
+        "properties": {}
+      },
+      {
+        "id": "r10",
+        "type": "HAS_OPPOSITION",
+        "fromId": "n0",
+        "toId": "n9",
+        "properties": {}
+      },
+      {
+        "id": "r11",
+        "type": "RAISED",
+        "fromId": "n10",
+        "toId": "n9",
+        "properties": {}
+      },
+      {
+        "id": "r12",
+        "type": "HAS_PRIORITY",
+        "fromId": "n0",
+        "toId": "n11",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/patient-journey.json
+++ b/neo4j-modeling-skill/references/patient-journey.json
@@ -1,0 +1,235 @@
+{
+  "id": "patient-journey",
+  "name": "Patient Journey",
+  "description": "Tracks patient healthcare journeys through encounters, observations, diagnoses, prescriptions, and providers. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/medical-care/patient-journey/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "healthcare",
+    "patient-journey",
+    "clinical",
+    "OMOP"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 50
+        },
+        "caption": "Patient",
+        "labels": [
+          "Patient"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string",
+          "birthDate": "date"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 200,
+          "y": 200
+        },
+        "caption": "Encounter",
+        "labels": [
+          "Encounter"
+        ],
+        "properties": {
+          "id": "string",
+          "date": "datetime",
+          "type": "string",
+          "description": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 500,
+          "y": 350
+        },
+        "caption": "Observation",
+        "labels": [
+          "Observation"
+        ],
+        "properties": {
+          "id": "string",
+          "code": "string",
+          "description": "string",
+          "value": "string",
+          "unit": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 200,
+          "y": 500
+        },
+        "caption": "Drug",
+        "labels": [
+          "Drug"
+        ],
+        "properties": {
+          "name": "string",
+          "code": "string",
+          "dosage": "string",
+          "frequency": "string"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 500,
+          "y": 500
+        },
+        "caption": "Condition",
+        "labels": [
+          "Condition"
+        ],
+        "properties": {
+          "description": "string",
+          "code": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 700,
+          "y": 200
+        },
+        "caption": "Provider",
+        "labels": [
+          "Provider"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#FCDC00",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n6",
+        "position": {
+          "x": 900,
+          "y": 100
+        },
+        "caption": "Speciality",
+        "labels": [
+          "Speciality"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n7",
+        "position": {
+          "x": 900,
+          "y": 300
+        },
+        "caption": "Organisation",
+        "labels": [
+          "Organisation"
+        ],
+        "properties": {
+          "id": "string",
+          "name": "string",
+          "address": "string"
+        },
+        "style": {
+          "color": "#68CCCA",
+          "radius": 40
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_ENCOUNTER",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "HAS_OBSERVATION",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "PRESCRIBED",
+        "fromId": "n1",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "DIAGNOSED",
+        "fromId": "n1",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "ATTENDED_BY",
+        "fromId": "n1",
+        "toId": "n5",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "HAS_SPECIALITY",
+        "fromId": "n5",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r6",
+        "type": "BELONGS_TO",
+        "fromId": "n5",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r7",
+        "type": "NEXT",
+        "fromId": "n1",
+        "toId": "n1",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/pipeline-intelligence.json
+++ b/neo4j-modeling-skill/references/pipeline-intelligence.json
@@ -1,0 +1,118 @@
+{
+  "id": "pipeline-intelligence",
+  "name": "Pharma Pipeline Intelligence",
+  "description": "Models the pharmaceutical R&D pipeline — companies, drugs, proteins/genes, diseases, clinical trials and phases — for competitive landscape analysis and strategic decisioning. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/competitive-intelligence/pipeline-intelligence/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "pipeline",
+    "pharma",
+    "competitive-intelligence",
+    "drug-development",
+    "clinical-trials",
+    "R&D"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 200 },
+        "caption": "Company",
+        "labels": ["Company"],
+        "properties": {
+          "name": "string",
+          "country": "string",
+          "market_cap": "integer",
+          "focus": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 400, "y": 350 },
+        "caption": "Drug",
+        "labels": ["Drug"],
+        "properties": {
+          "name": "string",
+          "mechanism": "string",
+          "modality": "string",
+          "status": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 55 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 400, "y": 100 },
+        "caption": "Protein",
+        "labels": ["Protein"],
+        "properties": {
+          "name": "string",
+          "function": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 45 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 250, "y": 100 },
+        "caption": "Gene",
+        "labels": ["Gene"],
+        "properties": {
+          "symbol": "string",
+          "name": "string"
+        },
+        "style": { "color": "#7B64FF", "radius": 45 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 700, "y": 200 },
+        "caption": "ClinicalTrial",
+        "labels": ["ClinicalTrial"],
+        "properties": {
+          "nct_id": "string",
+          "status": "string",
+          "start_date": "date",
+          "completion_date": "date",
+          "enrollment": "integer",
+          "termination_reason": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 900, "y": 200 },
+        "caption": "Phase",
+        "labels": ["Phase"],
+        "properties": {
+          "name": "string",
+          "number": "integer"
+        },
+        "style": { "color": "#FCDC00", "radius": 42 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 550, "y": 500 },
+        "caption": "Disease",
+        "labels": ["Disease"],
+        "properties": {
+          "name": "string",
+          "therapeuticArea": "string",
+          "icd10": "string"
+        },
+        "style": { "color": "#A4DD00", "radius": 50 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "IN_PIPELINE", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "TARGETS", "fromId": "n1", "toId": "n2", "properties": { "mechanism": "string" } },
+      { "id": "r2", "type": "TARGETS", "fromId": "n1", "toId": "n3", "properties": { "mechanism": "string" } },
+      { "id": "r3", "type": "INVESTIGATED_IN", "fromId": "n1", "toId": "n4", "properties": {} },
+      { "id": "r4", "type": "INVESTIGATED_IN", "fromId": "n2", "toId": "n4", "properties": {} },
+      { "id": "r5", "type": "INVESTIGATED_IN", "fromId": "n3", "toId": "n4", "properties": {} },
+      { "id": "r6", "type": "HAS_PHASE", "fromId": "n4", "toId": "n5", "properties": {} },
+      { "id": "r7", "type": "FOR_DISEASE", "fromId": "n4", "toId": "n6", "properties": {} },
+      { "id": "r8", "type": "TREATS", "fromId": "n1", "toId": "n6", "properties": {} },
+      { "id": "r9", "type": "ASSOCIATED_WITH", "fromId": "n2", "toId": "n6", "properties": {} },
+      { "id": "r10", "type": "ASSOCIATED_WITH", "fromId": "n3", "toId": "n6", "properties": {} }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/process-monitoring-cpa.json
+++ b/neo4j-modeling-skill/references/process-monitoring-cpa.json
@@ -1,0 +1,123 @@
+{
+  "id": "process-monitoring-cpa",
+  "name": "Process Monitoring & Critical Path Analysis",
+  "description": "Models manufacturing processes with machines, jobs, dependencies and queue management for CPA. Source: https://neo4j.com/developer/industry-use-cases/manufacturing/production-planning-and-optimization/process-monitoring-and-cpa/",
+  "industry": "Manufacturing",
+  "tags": [
+    "process-monitoring",
+    "critical-path",
+    "production",
+    "scheduling"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 150,
+          "y": 100
+        },
+        "caption": "Machine",
+        "labels": [
+          "Machine"
+        ],
+        "properties": {
+          "processor_id": "string",
+          "name": "string",
+          "load": "integer"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 450,
+          "y": 100
+        },
+        "caption": "Process",
+        "labels": [
+          "Process"
+        ],
+        "properties": {
+          "process_id": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 300,
+          "y": 350
+        },
+        "caption": "Job",
+        "labels": [
+          "Job"
+        ],
+        "properties": {
+          "job_id": "string",
+          "name": "string",
+          "status": "string",
+          "duration": "float",
+          "quality_score": "float",
+          "completion_progress": "float"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 55
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "RUNS_ON",
+        "fromId": "n2",
+        "toId": "n0",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "IS_INSTANCE_OF",
+        "fromId": "n2",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "DEPENDS_ON",
+        "fromId": "n2",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "WAITS",
+        "fromId": "n2",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "QUEUE_HEAD",
+        "fromId": "n0",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "QUEUE_TAIL",
+        "fromId": "n0",
+        "toId": "n2",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/publication-intelligence.json
+++ b/neo4j-modeling-skill/references/publication-intelligence.json
@@ -1,0 +1,305 @@
+{
+  "id": "publication-intelligence",
+  "name": "Publication Intelligence",
+  "description": "Analyses scientific publication networks with papers, authors, institutions, journals, keywords, figures, genes, proteins, SNPs and diseases. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/competitive-intelligence/publication-intelligence/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "publication",
+    "research",
+    "competitive-intelligence",
+    "KOL"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 500,
+          "y": 250
+        },
+        "caption": "Publication",
+        "labels": [
+          "Publication"
+        ],
+        "properties": {
+          "id": "string",
+          "pmid": "string",
+          "title": "string",
+          "text": "string",
+          "abstract": "string",
+          "year": "integer",
+          "citations": "integer"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 300,
+          "y": 200
+        },
+        "caption": "Author",
+        "labels": [
+          "Author"
+        ],
+        "properties": {
+          "name": "string",
+          "h_index": "integer",
+          "expertise": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 100,
+          "y": 200
+        },
+        "caption": "Institution",
+        "labels": [
+          "Institution"
+        ],
+        "properties": {
+          "name": "string",
+          "type": "string",
+          "country": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "caption": "Journal",
+        "labels": [
+          "Journal"
+        ],
+        "properties": {
+          "name": "string",
+          "impactFactor": "float"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 400,
+          "y": 80
+        },
+        "caption": "Keyword",
+        "labels": [
+          "Keyword"
+        ],
+        "properties": {
+          "term": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 600,
+          "y": 80
+        },
+        "caption": "Figure",
+        "labels": [
+          "Figure"
+        ],
+        "properties": {
+          "id": "string",
+          "caption": "string"
+        },
+        "style": {
+          "color": "#FCDC00",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n6",
+        "position": {
+          "x": 800,
+          "y": 250
+        },
+        "caption": "Disease",
+        "labels": [
+          "Disease"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n7",
+        "position": {
+          "x": 600,
+          "y": 420
+        },
+        "caption": "Gene",
+        "labels": [
+          "Gene"
+        ],
+        "properties": {
+          "symbol": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#68CCCA",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n8",
+        "position": {
+          "x": 400,
+          "y": 420
+        },
+        "caption": "Protein",
+        "labels": [
+          "Protein"
+        ],
+        "properties": {
+          "name": "string"
+        },
+        "style": {
+          "color": "#DBDF00",
+          "radius": 42
+        }
+      },
+      {
+        "id": "n9",
+        "position": {
+          "x": 250,
+          "y": 500
+        },
+        "caption": "SNP",
+        "labels": [
+          "SNP"
+        ],
+        "properties": {
+          "rsid": "string",
+          "variant": "string",
+          "clinical_significance": "string"
+        },
+        "style": {
+          "color": "#FF6B6B",
+          "radius": 40
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_AUTHOR",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "IS_PART_OF",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "PUBLISHED_IN",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "HAS_KEYWORD",
+        "fromId": "n0",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "IS_A",
+        "fromId": "n4",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "HAS_FIGURE",
+        "fromId": "n0",
+        "toId": "n5",
+        "properties": {}
+      },
+      {
+        "id": "r6",
+        "type": "CITES",
+        "fromId": "n0",
+        "toId": "n0",
+        "properties": {}
+      },
+      {
+        "id": "r7",
+        "type": "MENTIONS",
+        "fromId": "n0",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r8",
+        "type": "MENTIONS",
+        "fromId": "n0",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r9",
+        "type": "MENTIONS",
+        "fromId": "n0",
+        "toId": "n8",
+        "properties": {}
+      },
+      {
+        "id": "r10",
+        "type": "CODES",
+        "fromId": "n8",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r11",
+        "type": "ASSOCIATED_WITH",
+        "fromId": "n9",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r12",
+        "type": "MENTIONS_VARIANT",
+        "fromId": "n0",
+        "toId": "n9",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/quote-fraud.json
+++ b/neo4j-modeling-skill/references/quote-fraud.json
@@ -1,0 +1,53 @@
+{
+  "id": "quote-fraud",
+  "name": "Insurance Quote Fraud",
+  "description": "Detects quote manipulation via linked list of Quote nodes tracking sequential changes with time deltas. Source: https://neo4j.com/developer/industry-use-cases/insurance/quote-fraud/",
+  "industry": "Insurance",
+  "tags": [
+    "insurance",
+    "quote-fraud",
+    "ghost-broking"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 300
+        },
+        "caption": "Quote",
+        "labels": [
+          "Quote"
+        ],
+        "properties": {
+          "firstname": "string",
+          "surname": "string",
+          "dob": "date",
+          "postcode": "string",
+          "passport": "string",
+          "longitude": "float",
+          "latitude": "float",
+          "created_date": "datetime",
+          "change_info": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 60
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "NEXT_QUOTE",
+        "fromId": "n0",
+        "toId": "n0",
+        "properties": {
+          "diff_seconds": "integer"
+        }
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/reference-models.md
+++ b/neo4j-modeling-skill/references/reference-models.md
@@ -1,0 +1,114 @@
+# Reference Model Catalog
+
+32 pre-built Neo4j property graph schemas across 6 industries. Load any model by ID with the injector script:
+
+```bash
+python3 <skill-dir>/scripts/inject.py <model-id>
+```
+
+Run `python3 <skill-dir>/scripts/inject.py --list` for the live catalog with node and relationship counts.
+
+## Financial Services (13)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `transaction-base-model` | Transaction & Account Base Model | 19 | 24 |
+| `fraud-event-sequence` | Fraud Event Sequence Model | 13 | 26 |
+| `regulatory-dependency-mapping` | Regulatory Dependency Mapping | 2 | 3 |
+| `mutual-fund-dependency` | Mutual Fund Dependency Analytics | 3 | 2 |
+| `deposit-analysis` | Deposit Analysis | 3 | 3 |
+| `account-takeover-fraud` | Account Takeover Fraud | 19 | 35 |
+| `automated-facial-recognition` | Automated Facial Recognition | 1 | 0 |
+| `synthetic-identity-fraud` | Synthetic Identity Fraud | 4 | 4 |
+| `transaction-fraud-ring` | Transaction Fraud Ring | 2 | 2 |
+| `transaction-monitoring` | Transaction Monitoring | 8 | 10 |
+| `transaction-fraud-detection` | Transaction Fraud Detection (IEEE-CIS) | 6 | 5 |
+| `customer-churn` | Graph-Aware Finance Churn Prediction | 4 | 4 |
+| `ubo-company-ownership` | Ultimate Beneficial Owner (UBO) & Company Ownership | 5 | 5 |
+
+## Insurance (2)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `claims-fraud` | Insurance Claims Fraud | 4 | 5 |
+| `quote-fraud` | Insurance Quote Fraud | 1 | 1 |
+
+## Healthcare & Life Sciences (7)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `patient-journey` | Patient Journey | 8 | 8 |
+| `patent-intelligence` | Patent Intelligence | 12 | 13 |
+| `publication-intelligence` | Publication Intelligence | 10 | 13 |
+| `pipeline-intelligence` | Pharma Pipeline Intelligence | 7 | 11 |
+| `drug-safety` | Drug Safety & Pharmacovigilance (FAERS) | 6 | 10 |
+| `single-omics` | Single-omics Data Integration | 10 | 14 |
+| `multi-omics` | Multi-omics Data Integration | 12 | 19 |
+
+## Manufacturing (4)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `ev-route-planning` | Electric Vehicle Route Planning | 3 | 3 |
+| `configurable-bom` | Configurable Bill of Materials | 4 | 9 |
+| `engineering-traceability` | Engineering Traceability | 4 | 4 |
+| `process-monitoring-cpa` | Process Monitoring & Critical Path Analysis | 3 | 6 |
+
+## Cybersecurity (3)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `vulnerability-prioritization` | Vulnerability Prioritization & Exposure Management | 8 | 7 |
+| `attack-path-analysis` | Attack Path Analysis | 6 | 6 |
+| `software-supply-chain-security` | Software Supply Chain Security (SBOM) | 5 | 5 |
+
+## Industry Agnostic (3)
+
+| ID | Name | Nodes | Rels |
+|---|---|---|---|
+| `entity-resolution` | Entity Resolution | 1 | 1 |
+| `it-service-graph` | IT Service Graph | 7 | 8 |
+| `iam-effective-access` | Identity & Access Management (Effective Access Analysis) | 5 | 7 |
+
+## Keyword Quick Reference
+
+| Keyword | Model ID |
+|---|---|
+| banking, transactions, KYC, base model | `transaction-base-model` |
+| fraud event sequence | `fraud-event-sequence` |
+| regulatory, compliance | `regulatory-dependency-mapping` |
+| mutual fund, investment | `mutual-fund-dependency` |
+| deposit | `deposit-analysis` |
+| account takeover, ATO | `account-takeover-fraud` |
+| facial recognition, biometric | `automated-facial-recognition` |
+| synthetic identity | `synthetic-identity-fraud` |
+| fraud ring, circular payments | `transaction-fraud-ring` |
+| transaction monitoring, AML | `transaction-monitoring` |
+| IEEE-CIS, fraud detection ML | `transaction-fraud-detection` |
+| customer churn, retention | `customer-churn` |
+| UBO, beneficial owner, 6AMLD | `ubo-company-ownership` |
+| insurance claims, crash for cash | `claims-fraud` |
+| insurance quote, ghost broker | `quote-fraud` |
+| patient journey, healthcare, OMOP | `patient-journey` |
+| patent, IP intelligence | `patent-intelligence` |
+| publication, KOL | `publication-intelligence` |
+| pharma pipeline, clinical trials | `pipeline-intelligence` |
+| drug safety, pharmacovigilance, FAERS | `drug-safety` |
+| single-omics, genomics | `single-omics` |
+| multi-omics | `multi-omics` |
+| EV, route planning | `ev-route-planning` |
+| BOM, bill of materials, CBOM | `configurable-bom` |
+| traceability, requirements, test cases | `engineering-traceability` |
+| process monitoring, critical path | `process-monitoring-cpa` |
+| vulnerability, CVE, VPEM | `vulnerability-prioritization` |
+| attack path, lateral movement | `attack-path-analysis` |
+| SBOM, software supply chain | `software-supply-chain-security` |
+| entity resolution, record linkage | `entity-resolution` |
+| CMDB, IT service graph, infrastructure | `it-service-graph` |
+| IAM, RBAC, effective access | `iam-effective-access` |
+
+## Notes
+
+- All reference models include curated positions and colours — do not re-layout automatically.
+- Some models include `constraints`, `indexes`, or `notes` fields in their JSON.
+- Source: https://neo4j.com/developer/industry-use-cases/

--- a/neo4j-modeling-skill/references/regulatory-dependency-mapping.json
+++ b/neo4j-modeling-skill/references/regulatory-dependency-mapping.json
@@ -1,0 +1,79 @@
+{
+  "id": "regulatory-dependency-mapping",
+  "name": "Regulatory Dependency Mapping",
+  "description": "Maps regulatory dependencies between standards and sections. Source: https://neo4j.com/developer/industry-use-cases/finserv/investment-banking/regulatory-dependency-mapping/",
+  "industry": "Financial Services",
+  "tags": [
+    "regulatory",
+    "compliance",
+    "investment-banking"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 100
+        },
+        "caption": "Standard",
+        "labels": [
+          "Standard"
+        ],
+        "properties": {
+          "id": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 400,
+          "y": 350
+        },
+        "caption": "Section",
+        "labels": [
+          "Section"
+        ],
+        "properties": {
+          "id": "string",
+          "title": "string",
+          "last_updated": "datetime"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "DEPENDS_ON",
+        "fromId": "n1",
+        "toId": "n0",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "DEPENDS_ON",
+        "fromId": "n1",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "RELATED",
+        "fromId": "n1",
+        "toId": "n1",
+        "properties": {
+          "subsection": "string"
+        }
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/schema-enforcement.md
+++ b/neo4j-modeling-skill/references/schema-enforcement.md
@@ -1,0 +1,67 @@
+# Schema Enforcement
+
+Run all DDL with `IF NOT EXISTS`. Apply before importing data.
+
+## Constraint Types
+
+```cypher
+// 1. Uniqueness constraint — every node type used in MERGE
+CREATE CONSTRAINT person_id_unique IF NOT EXISTS
+  FOR (p:Person) REQUIRE p.id IS UNIQUE;
+
+// 2. Existence constraint (Enterprise) — mandatory properties
+CREATE CONSTRAINT person_name_exists IF NOT EXISTS
+  FOR (p:Person) REQUIRE p.name IS NOT NULL;
+
+// 3. Property type constraint (Enterprise) — enforce data type
+CREATE CONSTRAINT person_born_integer IF NOT EXISTS
+  FOR (p:Person) REQUIRE p.born IS :: INTEGER;
+
+// 4. Key constraint (Enterprise) — unique + exists in one
+CREATE CONSTRAINT movie_tmdbid_key IF NOT EXISTS
+  FOR (m:Movie) REQUIRE m.tmdbId IS NODE KEY;
+```
+
+## Index Types
+
+```cypher
+// 5. Range index — equality and range filters on properties
+CREATE INDEX person_name_idx IF NOT EXISTS
+  FOR (p:Person) ON (p.name);
+
+// 6. Fulltext index — CONTAINS, STARTS WITH, free text search
+CREATE FULLTEXT INDEX person_fulltext IF NOT EXISTS
+  FOR (n:Person) ON EACH [n.name, n.bio];
+
+// 7. Vector index — embedding similarity search
+CREATE VECTOR INDEX chunk_embedding_idx IF NOT EXISTS
+  FOR (c:Chunk) ON (c.embedding)
+  OPTIONS { indexConfig: { `vector.dimensions`: 1536, `vector.similarity_function`: 'cosine' } };
+
+// 8. Relationship index — filter on rel properties
+CREATE INDEX acted_in_year_idx IF NOT EXISTS
+  FOR ()-[r:ACTED_IN]-() ON (r.year);
+```
+
+After creating indexes, poll until ONLINE:
+
+```cypher
+SHOW INDEXES YIELD name, state WHERE state <> 'ONLINE' RETURN name, state;
+```
+
+Do NOT use an index until state = `ONLINE`.
+
+## Vector / Embedding Property Modeling
+
+Store embeddings on dedicated `:Chunk` nodes, never on business nodes:
+
+```
+(:Document)-[:HAS_CHUNK]->(c:Chunk {text: "...", embedding: [...]})
+```
+
+Rules:
+- Chunk node: `text` (source text), `embedding` (float array), `chunkIndex` (int)
+- Parent document: metadata only (title, url, createdAt)
+- Vector index on `c.embedding` only
+- Chunk size 200–500 tokens with 20% overlap is production default [field]
+- Do NOT put embedding on `:Document` — makes the node too large and pollutes traversal

--- a/neo4j-modeling-skill/references/single-omics.json
+++ b/neo4j-modeling-skill/references/single-omics.json
@@ -1,0 +1,146 @@
+{
+  "id": "single-omics",
+  "name": "Single-omics Data Integration",
+  "description": "Integrates single-omics (RNA-seq) data with projects, samples, tissues, experiments, comparisons, genes, proteins, GO terms, identifiers and diseases. Source: https://neo4j.com/developer/industry-use-cases/life-sciences/research-development/single-omics/",
+  "industry": "Healthcare & Life Sciences",
+  "tags": [
+    "omics",
+    "RNA-seq",
+    "transcriptomics",
+    "drug-discovery",
+    "research"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 100, "y": 300 },
+        "caption": "Project",
+        "labels": ["Project"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 50 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 300, "y": 300 },
+        "caption": "Sample",
+        "labels": ["Sample"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 300, "y": 150 },
+        "caption": "Tissue",
+        "labels": ["Tissue"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 45 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 500, "y": 300 },
+        "caption": "Experiment",
+        "labels": ["Experiment"],
+        "properties": {
+          "sid": "string",
+          "type": "string"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 400, "y": 500 },
+        "caption": "Comparison",
+        "labels": ["Comparison"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 50 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 700, "y": 300 },
+        "caption": "Gene",
+        "labels": ["Gene"],
+        "properties": {
+          "sid": "string",
+          "source": "string",
+          "symbol": "string"
+        },
+        "style": { "color": "#FCDC00", "radius": 50 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 700, "y": 150 },
+        "caption": "ID",
+        "labels": ["ID"],
+        "properties": {
+          "sid": "string",
+          "source": "string"
+        },
+        "style": { "color": "#A4DD00", "radius": 40 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": 900, "y": 300 },
+        "caption": "Protein",
+        "labels": ["Protein"],
+        "properties": {
+          "sid": "string",
+          "name": "string",
+          "uniprotId": "string"
+        },
+        "style": { "color": "#68CCCA",  "radius": 45 }
+      },
+      {
+        "id": "n8",
+        "position": { "x": 900, "y": 150 },
+        "caption": "GO",
+        "labels": ["GO"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#DBDF00", "radius": 40 }
+      },
+      {
+        "id": "n9",
+        "position": { "x": 700, "y": 500 },
+        "caption": "Disease",
+        "labels": ["Disease"],
+        "properties": {
+          "sid": "string",
+          "name": "string"
+        },
+        "style": { "color": "#FF6B6B", "radius": 45 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_SAMPLE", "fromId": "n0", "toId": "n1", "properties": {} },
+      { "id": "r1", "type": "TAKEN_FROM", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "HAS_EXPERIMENT", "fromId": "n1", "toId": "n3", "properties": {} },
+      { "id": "r3", "type": "COMPARES", "fromId": "n4", "toId": "n3", "properties": {} },
+      { "id": "r4", "type": "INCLUDES_CONTROL", "fromId": "n4", "toId": "n1", "properties": {} },
+      { "id": "r5", "type": "INCLUDES_CASE", "fromId": "n4", "toId": "n1", "properties": {} },
+      { "id": "r6", "type": "STUDIES_DISEASE", "fromId": "n4", "toId": "n9", "properties": {} },
+      { "id": "r7", "type": "FOUND_DIFFERENTIAL", "fromId": "n4", "toId": "n5", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string", "significance": "string" } },
+      { "id": "r8", "type": "HAS_VALUE", "fromId": "n3", "toId": "n5", "properties": { "logFC": "float", "pValue": "float", "adjPValue": "float", "regulated": "string" } },
+      { "id": "r9", "type": "MAPPED", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r10", "type": "CODES", "fromId": "n5", "toId": "n7", "properties": {} },
+      { "id": "r11", "type": "ASSOCIATED_WITH", "fromId": "n7", "toId": "n8", "properties": {} },
+      { "id": "r12", "type": "INTERACTS_WITH", "fromId": "n7", "toId": "n7", "properties": { "score": "float" } },
+      { "id": "r13", "type": "RELATED_TO", "fromId": "n5", "toId": "n9", "properties": {} }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/software-supply-chain-security.json
+++ b/neo4j-modeling-skill/references/software-supply-chain-security.json
@@ -1,0 +1,151 @@
+{
+  "id": "software-supply-chain-security",
+  "name": "Software Supply Chain Security (SBOM)",
+  "description": "Models software bill of materials connecting applications to libraries, vulnerabilities, and the CISA KEV catalog for supply chain risk analysis. Source: https://neo4j.com/developer/industry-use-cases/cybersecurity/software-supply-chain-security/",
+  "industry": "Cybersecurity",
+  "tags": [
+    "SBOM",
+    "supply-chain",
+    "dependencies",
+    "software-security"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 50
+        },
+        "caption": "Application",
+        "labels": [
+          "Application"
+        ],
+        "properties": {
+          "appId": "string",
+          "name": "string",
+          "version": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 200,
+          "y": 200
+        },
+        "caption": "Library",
+        "labels": [
+          "Library"
+        ],
+        "properties": {
+          "name": "string",
+          "version": "string",
+          "ecosystem": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 600,
+          "y": 200
+        },
+        "caption": "CVE",
+        "labels": [
+          "CVE"
+        ],
+        "properties": {
+          "id": "string",
+          "baseScore": "float",
+          "kev_addedDate": "datetime"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 200,
+          "y": 400
+        },
+        "caption": "BuildArtifact",
+        "labels": [
+          "BuildArtifact"
+        ],
+        "properties": {
+          "id": "string"
+        },
+        "style": {
+          "color": "#FE9200",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 600,
+          "y": 400
+        },
+        "caption": "Repo",
+        "labels": [
+          "Repo"
+        ],
+        "properties": {
+          "name": "string",
+          "criticality": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 45
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "RUNNING_AS",
+        "fromId": "n3",
+        "toId": "n0",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "DEPENDENCY_OF",
+        "fromId": "n1",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "IDENTIFIED_IN",
+        "fromId": "n2",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "DEPENDENCY_OF",
+        "fromId": "n1",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "BUILT_FROM",
+        "fromId": "n3",
+        "toId": "n4",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/synthetic-identity-fraud.json
+++ b/neo4j-modeling-skill/references/synthetic-identity-fraud.json
@@ -1,0 +1,119 @@
+{
+  "id": "synthetic-identity-fraud",
+  "name": "Synthetic Identity Fraud",
+  "description": "Detects synthetic identities via shared PII (email, phone, passport) between customers. Uses LINKED relationships for GDS community detection. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/synthetic-identity-fraud/",
+  "industry": "Financial Services",
+  "tags": [
+    "fraud",
+    "synthetic-identity",
+    "KYC",
+    "GDS"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 100
+        },
+        "caption": "Customer",
+        "labels": [
+          "Customer"
+        ],
+        "properties": {
+          "customerId": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 300
+        },
+        "caption": "Email",
+        "labels": [
+          "Email"
+        ],
+        "properties": {
+          "address": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 400,
+          "y": 300
+        },
+        "caption": "Phone",
+        "labels": [
+          "Phone"
+        ],
+        "properties": {
+          "phoneNumber": "string"
+        },
+        "style": {
+          "color": "#68CCCA",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 650,
+          "y": 300
+        },
+        "caption": "Passport",
+        "labels": [
+          "Passport"
+        ],
+        "properties": {
+          "passportNumber": "string"
+        },
+        "style": {
+          "color": "#AEA1FF",
+          "radius": 40
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_EMAIL",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "HAS_PHONE",
+        "fromId": "n0",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "HAS_PASSPORT",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "LINKED",
+        "fromId": "n0",
+        "toId": "n0",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/transaction-base-model.json
+++ b/neo4j-modeling-skill/references/transaction-base-model.json
@@ -1,0 +1,328 @@
+{
+  "id": "transaction-base-model",
+  "name": "Transaction & Account Base Model",
+  "description": "Neo4j standardised banking data model for transactions, accounts, customers, KYC identity documents, digital sessions, and fraud investigations. Source: https://neo4j.com/developer/industry-use-cases/data-models/transaction-graph/transaction/transaction-base-model/",
+  "industry": "Financial Services",
+  "tags": ["banking", "transactions", "fraud", "KYC", "AML", "retail-banking", "payments"],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 100 },
+        "caption": "Customer",
+        "labels": ["Customer"],
+        "properties": {
+          "customerId": "string",
+          "firstName": "string",
+          "middleName": "string",
+          "lastName": "string",
+          "dateOfBirth": "date",
+          "placeOfBirth": "string",
+          "countryOfBirth": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 100, "y": 300 },
+        "caption": "Account",
+        "labels": ["Account"],
+        "properties": {
+          "accountNumber": "string",
+          "accountType": "string",
+          "openedDate": "datetime",
+          "closedDate": "datetime",
+          "suspendedDate": "datetime"
+        },
+        "style": { "color": "#009CE0", "radius": 55 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 400, "y": 450 },
+        "caption": "Transaction",
+        "labels": ["Transaction"],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime",
+          "message": "string",
+          "type": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 700, "y": 300 },
+        "caption": "Counterparty",
+        "labels": ["Counterparty"],
+        "properties": {
+          "counterpartyId": "string",
+          "name": "string",
+          "type": "string",
+          "registrationNumber": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 100, "y": 600 },
+        "caption": "Movement",
+        "labels": ["Movement"],
+        "properties": {
+          "movementId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime",
+          "description": "string",
+          "status": "string",
+          "sequenceNumber": "integer",
+          "authorisedBy": "string",
+          "validatedBy": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FE9200", "radius": 45 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": 700, "y": 100 },
+        "caption": "Address",
+        "labels": ["Address"],
+        "properties": {
+          "addressLine1": "string",
+          "addressLine2": "string",
+          "postTown": "string",
+          "postCode": "string",
+          "region": "string",
+          "latitude": "float",
+          "longitude": "float",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FCDC00", "radius": 45 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 950, "y": 100 },
+        "caption": "Country",
+        "labels": ["Country"],
+        "properties": {
+          "code": "string",
+          "name": "string"
+        },
+        "style": { "color": "#73D8FF", "radius": 40 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": 150, "y": -100 },
+        "caption": "Email",
+        "labels": ["Email"],
+        "properties": {
+          "address": "string",
+          "domain": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#A4DD00", "radius": 40 }
+      },
+      {
+        "id": "n8",
+        "position": { "x": 400, "y": -100 },
+        "caption": "Phone",
+        "labels": ["Phone"],
+        "properties": {
+          "phoneNumber": "string",
+          "countryCode": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#68CCCA", "radius": 40 }
+      },
+      {
+        "id": "n9",
+        "position": { "x": 650, "y": -100 },
+        "caption": "Passport",
+        "labels": ["Passport"],
+        "properties": {
+          "passportNumber": "string",
+          "issueDate": "date",
+          "expiryDate": "date",
+          "issuingCountry": "string",
+          "nationality": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#AEA1FF", "radius": 40 }
+      },
+      {
+        "id": "n10",
+        "position": { "x": 900, "y": -100 },
+        "caption": "DrivingLicense",
+        "labels": ["DrivingLicense"],
+        "properties": {
+          "licenseNumber": "string",
+          "issueDate": "date",
+          "expiryDate": "date",
+          "issuingCountry": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#FDA1FF", "radius": 40 }
+      },
+      {
+        "id": "n11",
+        "position": { "x": -200, "y": 100 },
+        "caption": "Session",
+        "labels": ["Session"],
+        "properties": {
+          "sessionId": "string",
+          "status": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#F44E3B", "radius": 45 }
+      },
+      {
+        "id": "n12",
+        "position": { "x": -200, "y": -100 },
+        "caption": "Device",
+        "labels": ["Device"],
+        "properties": {
+          "deviceId": "string",
+          "deviceType": "string",
+          "userAgent": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#D33115", "radius": 40 }
+      },
+      {
+        "id": "n13",
+        "position": { "x": -450, "y": -100 },
+        "caption": "IP",
+        "labels": ["IP"],
+        "properties": {
+          "ipAddress": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#E27300", "radius": 40 }
+      },
+      {
+        "id": "n14",
+        "position": { "x": -450, "y": 100 },
+        "caption": "ISP",
+        "labels": ["ISP"],
+        "properties": {
+          "name": "string",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#B0BC00", "radius": 35 }
+      },
+      {
+        "id": "n15",
+        "position": { "x": -450, "y": -300 },
+        "caption": "Location",
+        "labels": ["Location"],
+        "properties": {
+          "city": "string",
+          "postCode": "string",
+          "country": "string",
+          "latitude": "float",
+          "longitude": "float",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#16A5A5", "radius": 40 }
+      },
+      {
+        "id": "n16",
+        "position": { "x": 100, "y": -300 },
+        "caption": "Face",
+        "labels": ["Face"],
+        "properties": {
+          "faceId": "string",
+          "embedding": "list_of_float",
+          "createdAt": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 35 }
+      },
+      {
+        "id": "n17",
+        "position": { "x": 400, "y": 700 },
+        "caption": "Alert",
+        "labels": ["Alert"],
+        "properties": {
+          "alertId": "string",
+          "ruleName": "string",
+          "ruleId": "string",
+          "severity": "string",
+          "triggeredAt": "datetime"
+        },
+        "style": { "color": "#F44E3B", "radius": 40 }
+      },
+      {
+        "id": "n18",
+        "position": { "x": 700, "y": 700 },
+        "caption": "Case",
+        "labels": ["Case"],
+        "properties": {
+          "caseId": "string",
+          "status": "string",
+          "outcome": "string",
+          "financialStakes": "float",
+          "investigatedBy": "string",
+          "createdAt": "datetime",
+          "closedAt": "datetime"
+        },
+        "style": { "color": "#D33115", "radius": 45 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HAS_ACCOUNT", "fromId": "n0", "toId": "n1", "properties": { "role": "string", "since": "datetime" } },
+      { "id": "r1", "type": "PERFORMS", "fromId": "n1", "toId": "n2", "properties": {} },
+      { "id": "r2", "type": "BENEFITS_TO", "fromId": "n2", "toId": "n1", "properties": {} },
+      { "id": "r3", "type": "HAS_ACCOUNT", "fromId": "n3", "toId": "n1", "properties": { "since": "datetime" } },
+      { "id": "r4", "type": "IMPLIED", "fromId": "n2", "toId": "n4", "properties": { "totalMovements": "integer" } },
+      { "id": "r5", "type": "HAS_ADDRESS", "fromId": "n0", "toId": "n5", "properties": { "addedAt": "datetime", "lastChangedAt": "datetime", "isCurrent": "boolean" } },
+      { "id": "r6", "type": "HAS_ADDRESS", "fromId": "n3", "toId": "n5", "properties": { "since": "datetime", "isCurrent": "boolean" } },
+      { "id": "r7", "type": "LOCATED_IN", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r8", "type": "IS_HOSTED", "fromId": "n1", "toId": "n6", "properties": {} },
+      { "id": "r9", "type": "HAS_EMAIL", "fromId": "n0", "toId": "n7", "properties": { "since": "datetime" } },
+      { "id": "r10", "type": "HAS_PHONE", "fromId": "n0", "toId": "n8", "properties": { "since": "datetime" } },
+      { "id": "r11", "type": "HAS_PASSPORT", "fromId": "n0", "toId": "n9", "properties": { "verificationDate": "datetime", "verificationMethod": "string", "verificationStatus": "string" } },
+      { "id": "r12", "type": "HAS_DRIVING_LICENSE", "fromId": "n0", "toId": "n10", "properties": { "verificationDate": "datetime", "verificationMethod": "string", "verificationStatus": "string" } },
+      { "id": "r13", "type": "HAS_NATIONALITY", "fromId": "n0", "toId": "n6", "properties": {} },
+      { "id": "r14", "type": "HAS_FACE", "fromId": "n0", "toId": "n16", "properties": { "verificationDate": "datetime", "verificationMethod": "string", "verificationStatus": "string" } },
+      { "id": "r15", "type": "SESSION_USES_DEVICE", "fromId": "n11", "toId": "n12", "properties": {} },
+      { "id": "r16", "type": "USES_IP", "fromId": "n11", "toId": "n13", "properties": {} },
+      { "id": "r17", "type": "USED_BY", "fromId": "n12", "toId": "n0", "properties": { "lastUsed": "datetime" } },
+      { "id": "r18", "type": "IS_ALLOCATED_TO", "fromId": "n13", "toId": "n14", "properties": { "createdAt": "datetime" } },
+      { "id": "r19", "type": "LOCATED_IN", "fromId": "n13", "toId": "n15", "properties": { "createdAt": "datetime" } },
+      { "id": "r20", "type": "LOCATED_IN", "fromId": "n15", "toId": "n6", "properties": {} },
+      { "id": "r21", "type": "TRIGGERED", "fromId": "n17", "toId": "n18", "properties": {} },
+      { "id": "r22", "type": "SUBJECT_OF", "fromId": "n1", "toId": "n18", "properties": {} },
+      { "id": "r23", "type": "SUBJECT_OF", "fromId": "n0", "toId": "n18", "properties": {} }
+    ],
+    "style": {}
+  },
+  "additionalLabels": {
+    "Account": ["Internal", "External", "HighRiskJurisdiction", "Flagged", "UnderInvestigation", "Confirmed"]
+  },
+  "constraints": [
+    "CREATE CONSTRAINT customer_id IF NOT EXISTS FOR (c:Customer) REQUIRE c.customerId IS NODE KEY",
+    "CREATE CONSTRAINT account_number IF NOT EXISTS FOR (a:Account) REQUIRE a.accountNumber IS NODE KEY",
+    "CREATE CONSTRAINT transaction_id IF NOT EXISTS FOR (t:Transaction) REQUIRE t.transactionId IS NODE KEY",
+    "CREATE CONSTRAINT email_address IF NOT EXISTS FOR (e:Email) REQUIRE e.address IS NODE KEY",
+    "CREATE CONSTRAINT phone_number IF NOT EXISTS FOR (p:Phone) REQUIRE p.number IS NODE KEY",
+    "CREATE CONSTRAINT passport_number IF NOT EXISTS FOR (p:Passport) REQUIRE (p.passportNumber, p.issuingCountry) IS NODE KEY",
+    "CREATE CONSTRAINT driving_license_composite IF NOT EXISTS FOR (d:DrivingLicense) REQUIRE (d.licenseNumber, d.issuingCountry) IS NODE KEY",
+    "CREATE CONSTRAINT device_id IF NOT EXISTS FOR (d:Device) REQUIRE d.deviceId IS NODE KEY",
+    "CREATE CONSTRAINT ip_address IF NOT EXISTS FOR (i:IP) REQUIRE i.ipAddress IS NODE KEY",
+    "CREATE CONSTRAINT session_id IF NOT EXISTS FOR (s:Session) REQUIRE s.sessionId IS NODE KEY",
+    "CREATE CONSTRAINT face_id IF NOT EXISTS FOR (f:Face) REQUIRE f.faceId IS NODE KEY",
+    "CREATE CONSTRAINT counterparty_id IF NOT EXISTS FOR (cp:Counterparty) REQUIRE cp.counterpartyId IS NODE KEY",
+    "CREATE CONSTRAINT movement_id IF NOT EXISTS FOR (m:Movement) REQUIRE m.movementId IS NODE KEY",
+    "CREATE CONSTRAINT isp_name IF NOT EXISTS FOR (i:ISP) REQUIRE i.name IS NODE KEY",
+    "CREATE CONSTRAINT country_code IF NOT EXISTS FOR (c:Country) REQUIRE c.code IS NODE KEY",
+    "CREATE CONSTRAINT address_composite IF NOT EXISTS FOR (a:Address) REQUIRE (a.addressLine1, a.postTown, a.postCode) IS NODE KEY",
+    "CREATE CONSTRAINT alert_id IF NOT EXISTS FOR (a:Alert) REQUIRE a.alertId IS NODE KEY",
+    "CREATE CONSTRAINT case_id IF NOT EXISTS FOR (c:Case) REQUIRE c.caseId IS NODE KEY"
+  ],
+  "indexes": [
+    "CREATE INDEX transaction_date_idx IF NOT EXISTS FOR (t:Transaction) ON (t.date)",
+    "CREATE INDEX transaction_amount_idx IF NOT EXISTS FOR (t:Transaction) ON (t.amount)"
+  ]
+}

--- a/neo4j-modeling-skill/references/transaction-fraud-detection.json
+++ b/neo4j-modeling-skill/references/transaction-fraud-detection.json
@@ -1,0 +1,165 @@
+{
+  "id": "transaction-fraud-detection",
+  "name": "Transaction Fraud Detection (IEEE-CIS)",
+  "description": "Graph-based fraud detection with Transaction, Card, Device, Email, Address, Identity nodes for ML feature engineering. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/ieee-cis-fraud-graphs/",
+  "industry": "Financial Services",
+  "tags": [
+    "fraud-detection",
+    "IEEE-CIS",
+    "machine-learning",
+    "GDS"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 100
+        },
+        "caption": "Transaction",
+        "labels": [
+          "Transaction"
+        ],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "isFraud": "boolean",
+          "productCD": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 100
+        },
+        "caption": "Card",
+        "labels": [
+          "Card"
+        ],
+        "properties": {
+          "cardId": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 650,
+          "y": 100
+        },
+        "caption": "Device",
+        "labels": [
+          "Device"
+        ],
+        "properties": {
+          "deviceId": "string"
+        },
+        "style": {
+          "color": "#D33115",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 150,
+          "y": 350
+        },
+        "caption": "Email",
+        "labels": [
+          "Email"
+        ],
+        "properties": {
+          "domain": "string"
+        },
+        "style": {
+          "color": "#A4DD00",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 400,
+          "y": 350
+        },
+        "caption": "Address",
+        "labels": [
+          "Address"
+        ],
+        "properties": {
+          "addressId": "string"
+        },
+        "style": {
+          "color": "#FCDC00",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 650,
+          "y": 350
+        },
+        "caption": "Identity",
+        "labels": [
+          "Identity"
+        ],
+        "properties": {
+          "identityId": "string"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 40
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "USED_CARD",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "USED_DEVICE",
+        "fromId": "n0",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "HAS_EMAIL",
+        "fromId": "n0",
+        "toId": "n3",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "HAS_ADDRESS",
+        "fromId": "n0",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "HAS_IDENTITY",
+        "fromId": "n0",
+        "toId": "n5",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/transaction-fraud-ring.json
+++ b/neo4j-modeling-skill/references/transaction-fraud-ring.json
@@ -1,0 +1,71 @@
+{
+  "id": "transaction-fraud-ring",
+  "name": "Transaction Fraud Ring",
+  "description": "Detects circular transaction flows between accounts. Uses Account and Transaction nodes with PERFORMS/BENEFITS_TO ring pattern. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/transaction-ring/",
+  "industry": "Financial Services",
+  "tags": [
+    "fraud-ring",
+    "transaction-fraud",
+    "APP-fraud"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 250,
+          "y": 250
+        },
+        "caption": "Account",
+        "labels": [
+          "Account"
+        ],
+        "properties": {
+          "accountNumber": "string"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 550,
+          "y": 250
+        },
+        "caption": "Transaction",
+        "labels": [
+          "Transaction"
+        ],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "PERFORMS",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "BENEFITS_TO",
+        "fromId": "n1",
+        "toId": "n0",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/transaction-monitoring.json
+++ b/neo4j-modeling-skill/references/transaction-monitoring.json
@@ -1,0 +1,255 @@
+{
+  "id": "transaction-monitoring",
+  "name": "Transaction Monitoring",
+  "description": "AML transaction monitoring linking accounts, transactions, counterparties and jurisdictions. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/transaction-monitoring/transaction-monitoring-introduction/",
+  "industry": "Financial Services",
+  "tags": [
+    "AML",
+    "transaction-monitoring",
+    "compliance"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": {
+          "x": 400,
+          "y": 50
+        },
+        "caption": "Customer",
+        "labels": [
+          "Customer"
+        ],
+        "properties": {
+          "customerId": "string",
+          "name": "string",
+          "riskRating": "string"
+        },
+        "style": {
+          "color": "#68BC00",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n1",
+        "position": {
+          "x": 150,
+          "y": 200
+        },
+        "caption": "Account",
+        "labels": [
+          "Account",
+          "Internal"
+        ],
+        "properties": {
+          "accountNumber": "string",
+          "accountType": "string",
+          "openedDate": "datetime"
+        },
+        "style": {
+          "color": "#009CE0",
+          "radius": 55
+        }
+      },
+      {
+        "id": "n2",
+        "position": {
+          "x": 400,
+          "y": 350
+        },
+        "caption": "Transaction",
+        "labels": [
+          "Transaction"
+        ],
+        "properties": {
+          "transactionId": "string",
+          "amount": "float",
+          "currency": "string",
+          "date": "datetime",
+          "type": "string"
+        },
+        "style": {
+          "color": "#FA28FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n3",
+        "position": {
+          "x": 650,
+          "y": 200
+        },
+        "caption": "Counterparty",
+        "labels": [
+          "Counterparty"
+        ],
+        "properties": {
+          "counterpartyId": "string",
+          "name": "string",
+          "type": "string"
+        },
+        "style": {
+          "color": "#7B64FF",
+          "radius": 50
+        }
+      },
+      {
+        "id": "n4",
+        "position": {
+          "x": 650,
+          "y": 50
+        },
+        "caption": "Country",
+        "labels": [
+          "Country"
+        ],
+        "properties": {
+          "code": "string",
+          "name": "string"
+        },
+        "style": {
+          "color": "#73D8FF",
+          "radius": 40
+        }
+      },
+      {
+        "id": "n5",
+        "position": {
+          "x": 400,
+          "y": 550
+        },
+        "caption": "Alert",
+        "labels": [
+          "Alert"
+        ],
+        "properties": {
+          "alertId": "string",
+          "ruleName": "string",
+          "severity": "string",
+          "triggeredAt": "datetime"
+        },
+        "style": {
+          "color": "#F44E3B",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n6",
+        "position": {
+          "x": 150,
+          "y": 400
+        },
+        "caption": "Case",
+        "labels": [
+          "Case"
+        ],
+        "properties": {
+          "caseId": "string",
+          "status": "string",
+          "outcome": "string",
+          "createdAt": "datetime",
+          "closedAt": "datetime",
+          "financialStakes": "float",
+          "investigatedBy": "string"
+        },
+        "style": {
+          "color": "#D33115",
+          "radius": 45
+        }
+      },
+      {
+        "id": "n7",
+        "position": {
+          "x": 900,
+          "y": 350
+        },
+        "caption": "Account",
+        "labels": [
+          "Account",
+          "External",
+          "HighRiskJurisdiction"
+        ],
+        "properties": {
+          "accountNumber": "string"
+        },
+        "style": {
+          "color": "#FB9E00",
+          "radius": 55
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "id": "r0",
+        "type": "HAS_ACCOUNT",
+        "fromId": "n0",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r1",
+        "type": "PERFORMS",
+        "fromId": "n1",
+        "toId": "n2",
+        "properties": {}
+      },
+      {
+        "id": "r2",
+        "type": "BENEFITS_TO",
+        "fromId": "n2",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r3",
+        "type": "HAS_ACCOUNT",
+        "fromId": "n3",
+        "toId": "n1",
+        "properties": {}
+      },
+      {
+        "id": "r4",
+        "type": "IS_HOSTED",
+        "fromId": "n1",
+        "toId": "n4",
+        "properties": {}
+      },
+      {
+        "id": "r5",
+        "type": "TRIGGERED",
+        "fromId": "n5",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r6",
+        "type": "SUBJECT_OF",
+        "fromId": "n1",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r7",
+        "type": "SUBJECT_OF",
+        "fromId": "n0",
+        "toId": "n6",
+        "properties": {}
+      },
+      {
+        "id": "r8",
+        "type": "BENEFITS_TO",
+        "fromId": "n2",
+        "toId": "n7",
+        "properties": {}
+      },
+      {
+        "id": "r9",
+        "type": "IS_HOSTED",
+        "fromId": "n7",
+        "toId": "n4",
+        "properties": {}
+      }
+    ],
+    "style": {}
+  }
+}

--- a/neo4j-modeling-skill/references/ubo-company-ownership.json
+++ b/neo4j-modeling-skill/references/ubo-company-ownership.json
@@ -1,0 +1,95 @@
+{
+  "id": "ubo-company-ownership",
+  "name": "Ultimate Beneficial Owner (UBO) & Company Ownership",
+  "description": "Models corporate ownership hierarchies across individuals, companies, and legal entities for UBO identification and AML/KYC compliance (6AMLD). Built on UK Companies House datasets. Source: https://neo4j.com/developer/industry-use-cases/finserv/retail-banking/company-ownership-ubo-graphs/",
+  "industry": "Financial Services",
+  "tags": [
+    "UBO",
+    "beneficial-ownership",
+    "KYC",
+    "AML",
+    "6AMLD",
+    "company-ownership",
+    "corporate-structure"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 100 },
+        "caption": "Company",
+        "labels": ["Company"],
+        "properties": {
+          "companyNumber": "string",
+          "companyName": "string",
+          "companyCategory": "string",
+          "companyStatus": "string",
+          "incorporationDate": "date",
+          "jurisdiction": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 100, "y": 300 },
+        "caption": "Individual",
+        "labels": ["Individual"],
+        "properties": {
+          "personId": "string",
+          "firstName": "string",
+          "lastName": "string",
+          "dateOfBirth": "date",
+          "nationality": "string",
+          "countryOfResidence": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 700, "y": 300 },
+        "caption": "LegalEntity",
+        "labels": ["LegalEntity"],
+        "properties": {
+          "entityId": "string",
+          "name": "string",
+          "entityType": "string",
+          "jurisdiction": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 400, "y": 450 },
+        "caption": "Address",
+        "labels": ["Address"],
+        "properties": {
+          "addressLine1": "string",
+          "postTown": "string",
+          "postCode": "string",
+          "country": "string"
+        },
+        "style": { "color": "#7B64FF", "radius": 45 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": 100, "y": 450 },
+        "caption": "SIC",
+        "labels": ["SIC"],
+        "properties": {
+          "sicCode": "string",
+          "description": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 40 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "OWNS", "fromId": "n0", "toId": "n0", "properties": { "ownership_pct_min": "float", "ownership_pct_max": "float", "natureOfControl": "string" } },
+      { "id": "r1", "type": "OWNS", "fromId": "n1", "toId": "n0", "properties": { "ownership_pct_min": "float", "ownership_pct_max": "float", "natureOfControl": "string" } },
+      { "id": "r2", "type": "OWNS", "fromId": "n2", "toId": "n0", "properties": { "ownership_pct_min": "float", "ownership_pct_max": "float", "natureOfControl": "string" } },
+      { "id": "r3", "type": "REGISTERED_AT", "fromId": "n0", "toId": "n3", "properties": {} },
+      { "id": "r4", "type": "HAS_SIC", "fromId": "n0", "toId": "n4", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "UBO is typically determined by finding the Individual(s) at the top of the OWNS/CONTROLS chain holding >=25% (direct + indirect). Use apoc.path.expandConfig on OWNS with variable depth to traverse multi-layer hierarchies."
+}

--- a/neo4j-modeling-skill/references/vulnerability-prioritization.json
+++ b/neo4j-modeling-skill/references/vulnerability-prioritization.json
@@ -1,0 +1,128 @@
+{
+  "id": "vulnerability-prioritization",
+  "name": "Vulnerability Prioritization & Exposure Management",
+  "description": "VPEM model connecting code to cloud: compute instances, applications, libraries/SBOMs, CVEs, identities, IAM policies and cloud services for risk-based prioritization. Includes CISA KEV threat intelligence. Source: https://neo4j.com/developer/industry-use-cases/cybersecurity/vulnerability-prioritization-exposure-management/",
+  "industry": "Cybersecurity",
+  "tags": [
+    "vulnerability",
+    "CVE",
+    "VPEM",
+    "exposure-management",
+    "SBOM",
+    "IAM",
+    "CISA-KEV"
+  ],
+  "initialGraph": {
+    "nodes": [
+      {
+        "id": "n0",
+        "position": { "x": 400, "y": 50 },
+        "caption": "ComputeInstance",
+        "labels": ["ComputeInstance"],
+        "properties": {
+          "instanceId": "string",
+          "hostname": "string",
+          "publicIp": "string",
+          "os": "string"
+        },
+        "style": { "color": "#68BC00", "radius": 55 }
+      },
+      {
+        "id": "n1",
+        "position": { "x": 150, "y": 200 },
+        "caption": "Application",
+        "labels": ["Application"],
+        "properties": {
+          "appId": "string",
+          "name": "string",
+          "version": "string"
+        },
+        "style": { "color": "#009CE0", "radius": 50 }
+      },
+      {
+        "id": "n2",
+        "position": { "x": 400, "y": 350 },
+        "caption": "Library",
+        "labels": ["Library"],
+        "properties": {
+          "name": "string",
+          "version": "string",
+          "ecosystem": "string"
+        },
+        "style": { "color": "#FA28FF", "radius": 50 }
+      },
+      {
+        "id": "n3",
+        "position": { "x": 700, "y": 350 },
+        "caption": "CVE",
+        "labels": ["CVE"],
+        "properties": {
+          "id": "string",
+          "baseScore": "float",
+          "kev_addedDate": "datetime"
+        },
+        "style": { "color": "#7B64FF", "radius": 50 }
+      },
+      {
+        "id": "n4",
+        "position": { "x": -100, "y": 350 },
+        "caption": "Identity",
+        "labels": ["Identity"],
+        "properties": {
+          "identityId": "string",
+          "name": "string",
+          "type": "string"
+        },
+        "style": { "color": "#FE9200", "radius": 45 }
+      },
+      {
+        "id": "n5",
+        "position": { "x": -100, "y": 550 },
+        "caption": "IAMPolicy",
+        "labels": ["IAMPolicy"],
+        "properties": {
+          "policyId": "string",
+          "name": "string",
+          "document": "string"
+        },
+        "style": { "color": "#FCDC00", "radius": 45 }
+      },
+      {
+        "id": "n6",
+        "position": { "x": 200, "y": 700 },
+        "caption": "CloudService",
+        "labels": ["CloudService"],
+        "properties": {
+          "serviceId": "string",
+          "name": "string",
+          "type": "string"
+        },
+        "style": { "color": "#A4DD00", "radius": 45 }
+      },
+      {
+        "id": "n7",
+        "position": { "x": 700, "y": 550 },
+        "caption": "CisaKEV",
+        "labels": ["CisaKEV"],
+        "properties": {
+          "cveId": "string",
+          "dateAdded": "date",
+          "vendorProject": "string",
+          "product": "string"
+        },
+        "style": { "color": "#D33115", "radius": 40 }
+      }
+    ],
+    "relationships": [
+      { "id": "r0", "type": "HOSTED_ON", "fromId": "n1", "toId": "n0", "properties": {} },
+      { "id": "r1", "type": "DEPENDENCY_OF", "fromId": "n2", "toId": "n1", "properties": {} },
+      { "id": "r2", "type": "IDENTIFIED_IN", "fromId": "n3", "toId": "n2", "properties": {} },
+      { "id": "r3", "type": "AUTHENTICATES_VIA", "fromId": "n1", "toId": "n4", "properties": {} },
+      { "id": "r4", "type": "ASSUMES", "fromId": "n4", "toId": "n5", "properties": {} },
+      { "id": "r5", "type": "HAS_ACCESS_TO", "fromId": "n5", "toId": "n6", "properties": {} },
+      { "id": "r6", "type": "LISTED_IN", "fromId": "n3", "toId": "n7", "properties": {} }
+    ],
+    "style": {}
+  },
+  "notes": "Key traversal pattern for exposure analysis: (Application)-[:HOSTED_ON]->(ComputeInstance) and (Library)-[:DEPENDENCY_OF]->(Application)<-[:IDENTIFIED_IN]-(CVE). Blast-radius pattern: (Application)-[:AUTHENTICATES_VIA]->(Identity)-[:ASSUMES]->(IAMPolicy)-[:HAS_ACCESS_TO]->(CloudService). KEV inclusion is tracked via CVE.kev_addedDate or the LISTED_IN relationship to a CisaKEV node."
+}

--- a/neo4j-modeling-skill/scripts/inject.py
+++ b/neo4j-modeling-skill/scripts/inject.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""
+Unified injector for graph-schema-studio.
+
+Reads a schema definition from one of several sources, normalises it into the
+editor's initialGraph shape, and writes a ready-to-use React artifact to
+/mnt/user-data/outputs/graph-schema-editor.jsx by default.
+
+INPUT SOURCES
+-------------
+The script auto-detects the input source from the positional argument (or from
+stdin when no argument is given):
+
+  1. Reference-model ID (e.g. "claims-fraud"):
+        python3 inject.py claims-fraud
+     → resolves to references/claims-fraud.json in this skill
+
+  2. File path (absolute or relative):
+        python3 inject.py /home/claude/my_schema.json
+     → reads that file
+
+  3. Stdin (when no argument or when the argument is "-"):
+        cat <<EOF | python3 inject.py
+        { "nodes": [...], "relationships": [...] }
+        EOF
+
+  4. List available reference models:
+        python3 inject.py --list
+
+ACCEPTED SCHEMA SHAPES
+----------------------
+The normaliser accepts both the minimal custom shape and the full
+reference-model shape, unwrapping common containers automatically:
+
+  - Minimal custom:   { "nodes": [...], "relationships": [...] }
+  - arrows.app:       { "graph": { "nodes": [...], "relationships": [...] } }
+  - Reference model:  { "initialGraph": { "nodes": [...], "relationships": [...] }, ... }
+
+In minimal custom schemas, relationship endpoints can be given as `from`/`to`
+with node captions (the normaliser resolves them to ids) — or as explicit
+`fromId`/`toId` when two nodes share a caption.
+
+Any optional field (id, position, style, labels) is auto-filled with a
+sensible default when omitted, but any value the caller DOES supply is
+respected unchanged. This is what lets reference models keep their curated
+positions and colours while custom domains stay terse.
+
+OUTPUT
+------
+Pass an optional output path as the second positional argument:
+
+    python3 inject.py claims-fraud /tmp/my-editor.jsx
+
+Defaults to /mnt/user-data/outputs/graph-schema-editor.jsx.
+"""
+import json
+import sys
+import re
+import os
+import math
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+TEMPLATE_PATH = os.path.join(SKILL_DIR, "assets", "graph-editor-template.jsx")
+REFERENCES_DIR = os.path.join(SKILL_DIR, "references")
+
+
+def _default_output_dir():
+    """Pick a sensible default output directory for the running environment.
+
+    claude.ai chat mounts /mnt/user-data/outputs/, but other runtimes
+    (Cowork, Claude Code, API harnesses) may not. Fall back to the current
+    working directory so the injector still works there. Callers can always
+    override with an explicit second positional argument.
+    """
+    canonical = "/mnt/user-data/outputs"
+    if os.path.isdir(canonical):
+        return canonical
+    return os.getcwd()
+
+
+DEFAULT_OUTPUT = os.path.join(_default_output_dir(), "graph-schema-editor.jsx")
+
+# Keep in sync with the COLORS array at the top of the JSX template
+COLORS = [
+    "#4C8BF5", "#E5484D", "#30A46C", "#E38627", "#8B5CF6",
+    "#06B6D4", "#EC4899", "#F59E0B", "#6366F1", "#14B8A6",
+]
+
+DEFAULT_RADIUS = 55
+
+
+# ---------------------------------------------------------------------------
+# Reference model catalog
+# ---------------------------------------------------------------------------
+def list_reference_models():
+    """Return the reference model catalog, preferring model-index.json."""
+    index_path = os.path.join(REFERENCES_DIR, "model-index.json")
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            return json.load(f).get("models", [])
+    # Fallback: scan the references directory
+    models = []
+    if not os.path.isdir(REFERENCES_DIR):
+        return models
+    for f in sorted(os.listdir(REFERENCES_DIR)):
+        if f.endswith(".json") and f != "model-index.json":
+            with open(os.path.join(REFERENCES_DIR, f)) as fh:
+                m = json.load(fh)
+            models.append({
+                "id": m.get("id", f[:-5]),
+                "name": m.get("name", f[:-5]),
+                "industry": m.get("industry", ""),
+                "nodeCount": len(m.get("initialGraph", {}).get("nodes", [])),
+                "relationshipCount": len(m.get("initialGraph", {}).get("relationships", [])),
+            })
+    return models
+
+
+def print_reference_list():
+    models = list_reference_models()
+    if not models:
+        print(f"No reference models found in {REFERENCES_DIR}", file=sys.stderr)
+        sys.exit(1)
+    print(f"{'ID':<42} {'Industry':<28} {'N':>3} {'R':>3}")
+    print("-" * 80)
+    for m in models:
+        print(f"{m['id']:<42} {m.get('industry',''):<28} "
+              f"{m.get('nodeCount','?'):>3} {m.get('relationshipCount','?'):>3}")
+    print(f"\n{len(models)} reference models available in {REFERENCES_DIR}")
+
+
+# ---------------------------------------------------------------------------
+# Auto-layout for minimal schemas (nodes without explicit positions)
+# ---------------------------------------------------------------------------
+def auto_layout(n_nodes):
+    """Return (x, y) positions arranged around a circle centred on the viewport."""
+    if n_nodes == 0:
+        return []
+    if n_nodes == 1:
+        return [(450, 350)]
+    if n_nodes == 2:
+        return [(300, 300), (600, 300)]
+    cx, cy = 450, 350
+    radius = max(180, 60 * n_nodes / (2 * math.pi))
+    radius = min(radius, 320)
+    positions = []
+    for i in range(n_nodes):
+        angle = -math.pi / 2 + (2 * math.pi * i / n_nodes)
+        x = round(cx + radius * math.cos(angle))
+        y = round(cy + radius * math.sin(angle))
+        positions.append((x, y))
+    return positions
+
+
+# ---------------------------------------------------------------------------
+# Schema normalisation: converts any accepted input shape to a full initialGraph
+# ---------------------------------------------------------------------------
+def unwrap(raw):
+    """Unwrap common container keys so downstream logic sees a bare graph dict."""
+    if isinstance(raw, dict):
+        if "graph" in raw and isinstance(raw["graph"], dict):
+            return raw["graph"]
+        if "initialGraph" in raw and isinstance(raw["initialGraph"], dict):
+            return raw["initialGraph"]
+    return raw
+
+
+def normalise_schema(raw):
+    """Convert a minimal or fully-specified schema into a complete initialGraph.
+
+    Accepts THREE input flavours:
+      1. Minimal custom: {nodes:[{caption, properties}], relationships:[...]}
+      2. Our editor's arrows-ish format with explicit caption + style.color
+      3. Pure arrows.app format: caption empty, display text comes from
+         labels[0]; node colour lives in style.node-color (kebab-case);
+         radius may be inherited from a top-level style block.
+
+    The caller (whether the editor's Import button or inject.py on the CLI)
+    sees the same normalised output regardless of which flavour came in.
+    """
+    raw = unwrap(raw)
+
+    raw_nodes = raw.get("nodes") or []
+    raw_rels = raw.get("relationships") or []
+    # Top-level style block in arrows.app holds graph-wide defaults like
+    # `radius` and the giant set of styling keys. We preserve it opaquely
+    # for round-tripping, but also peek at it to inherit defaults.
+    top_style = raw.get("style") or {}
+    default_radius_from_style = top_style.get("radius") if isinstance(top_style, dict) else None
+
+    if not isinstance(raw_nodes, list):
+        raise ValueError("'nodes' must be a list")
+    if not isinstance(raw_rels, list):
+        raise ValueError("'relationships' must be a list")
+
+    positions = auto_layout(len(raw_nodes))
+    caption_to_id = {}
+    duplicate_captions = set()
+    nodes = []
+
+    for i, n in enumerate(raw_nodes):
+        if not isinstance(n, dict):
+            raise ValueError(f"Node {i} is not an object")
+
+        # Caption derivation: arrows.app often emits caption="" and relies on
+        # labels[0] for the display text. When caption is missing OR an empty
+        # string, fall through to labels[0]. Our editor will continue to keep
+        # caption populated internally, but we round-trip it correctly to
+        # arrows-style on output (see export below).
+        raw_caption = n.get("caption")
+        caption = raw_caption if (raw_caption and raw_caption.strip()) else None
+        if not caption:
+            labs = n.get("labels") or []
+            caption = labs[0] if labs else None
+        if not caption:
+            raise ValueError(f"Node {i} is missing both 'caption' and 'labels'")
+
+        nid = n.get("id") or f"n{i}"
+        # Track duplicates but don't fail yet — duplicate captions are only a
+        # problem if a relationship tries to resolve by caption later.
+        if caption in caption_to_id and caption_to_id[caption] != nid:
+            duplicate_captions.add(caption)
+        else:
+            caption_to_id[caption] = nid
+
+        pos = n.get("position") or {"x": positions[i][0], "y": positions[i][1]}
+        style = n.get("style") or {}
+        # Colour: accept BOTH our internal `color` and arrows.app's
+        # `node-color` (kebab-case). Internal form wins if both are set.
+        color = (
+            style.get("color")
+            or style.get("node-color")
+            or COLORS[i % len(COLORS)]
+        )
+        # Radius: node-level radius wins, then fall back to the graph-wide
+        # default in the top-level style block, then to our internal default.
+        radius = (
+            style.get("radius")
+            or default_radius_from_style
+            or DEFAULT_RADIUS
+        )
+        props = n.get("properties") or {}
+
+        # Label normalisation: the labels array always starts with caption,
+        # followed by any additional labels (Neo4j multi-label syntax
+        # :Account:Internal). This invariant keeps the editor UI, the Cypher
+        # export, and the arrows.app export consistent with each other.
+        raw_labels = n.get("labels") or [caption]
+        seen = set()
+        extras = []
+        for lab in raw_labels:
+            if not isinstance(lab, str):
+                continue
+            lab = lab.strip()
+            if not lab or lab == caption or lab in seen:
+                continue
+            seen.add(lab)
+            extras.append(lab)
+        labels = [caption] + extras
+
+        nodes.append({
+            "id": nid,
+            "position": {"x": pos["x"], "y": pos["y"]},
+            "caption": caption,
+            "labels": labels,
+            "properties": props,
+            "style": {"color": color, "radius": radius},
+        })
+
+    rels = []
+    for i, r in enumerate(raw_rels):
+        if not isinstance(r, dict):
+            raise ValueError(f"Relationship {i} is not an object")
+
+        rtype = r.get("type")
+        if not rtype:
+            raise ValueError(f"Relationship {i} is missing 'type'")
+
+        # Explicit ids win. Only fall back to caption lookup when the caller
+        # didn't supply them. Duplicate captions are only fatal if actually
+        # consulted.
+        from_id = r.get("fromId")
+        if not from_id:
+            from_caption = r.get("from")
+            if from_caption in duplicate_captions:
+                raise ValueError(
+                    f"Relationship {i} ({rtype}): 'from' references duplicate "
+                    f"caption '{from_caption}'. Use explicit fromId instead."
+                )
+            from_id = caption_to_id.get(from_caption)
+
+        to_id = r.get("toId")
+        if not to_id:
+            to_caption = r.get("to")
+            if to_caption in duplicate_captions:
+                raise ValueError(
+                    f"Relationship {i} ({rtype}): 'to' references duplicate "
+                    f"caption '{to_caption}'. Use explicit toId instead."
+                )
+            to_id = caption_to_id.get(to_caption)
+
+        if not from_id:
+            raise ValueError(
+                f"Relationship {i} ({rtype}): cannot resolve 'from' / 'fromId'. "
+                f"Known captions: {list(caption_to_id.keys())}"
+            )
+        if not to_id:
+            raise ValueError(
+                f"Relationship {i} ({rtype}): cannot resolve 'to' / 'toId'. "
+                f"Known captions: {list(caption_to_id.keys())}"
+            )
+
+        rid = r.get("id") or f"r{i}"
+        rels.append({
+            "id": rid,
+            "type": rtype,
+            "fromId": from_id,
+            "toId": to_id,
+            "properties": r.get("properties") or {},
+        })
+
+    return {"nodes": nodes, "relationships": rels}
+
+
+# ---------------------------------------------------------------------------
+# JS emission (same single-line-per-node format the editor expects)
+# ---------------------------------------------------------------------------
+def to_js_initial_graph(ig):
+    lines = ["const initialGraph = {", "  nodes: ["]
+    for n in ig["nodes"]:
+        lines.append(
+            f'    {{ id: "{n["id"]}", position: {json.dumps(n["position"])}, '
+            f'caption: "{n["caption"]}", labels: {json.dumps(n["labels"])}, '
+            f'properties: {json.dumps(n["properties"])}, style: {json.dumps(n["style"])} }},'
+        )
+    lines.append("  ],")
+    lines.append("  relationships: [")
+    for r in ig["relationships"]:
+        lines.append(
+            f'    {{ id: "{r["id"]}", type: "{r["type"]}", '
+            f'fromId: "{r["fromId"]}", toId: "{r["toId"]}", '
+            f'properties: {json.dumps(r["properties"])} }},'
+        )
+    lines.append("  ],")
+    lines.append("  style: {},")
+    lines.append("};")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Input resolution
+# ---------------------------------------------------------------------------
+def resolve_input(arg):
+    """Turn the user's argument into a raw parsed JSON dict + a source label.
+
+    Tries in order:
+      - arg is a readable file path
+      - arg matches a reference model filename (references/<arg>.json or references/<arg>)
+      - arg matches a reference model's `id` field (scans references/*.json)
+
+    Returns (raw_dict, source_label, is_reference_model).
+    """
+    # 1. Explicit file path (absolute, relative, or just existing)
+    if os.path.exists(arg):
+        with open(arg) as f:
+            return json.load(f), arg, False
+
+    # 2. Reference model by filename
+    if os.path.isdir(REFERENCES_DIR):
+        candidate_id = os.path.join(REFERENCES_DIR, f"{arg}.json")
+        if os.path.exists(candidate_id):
+            with open(candidate_id) as f:
+                return json.load(f), candidate_id, True
+        candidate_file = os.path.join(REFERENCES_DIR, arg)
+        if os.path.exists(candidate_file):
+            with open(candidate_file) as f:
+                return json.load(f), candidate_file, True
+
+        # 3. Reference model by id field (handles cases where filename differs
+        #    from the id — e.g. fraud-event-sequence lives in
+        #    fraud-event-sequence-model.json)
+        for fname in sorted(os.listdir(REFERENCES_DIR)):
+            if not fname.endswith(".json") or fname == "model-index.json":
+                continue
+            fpath = os.path.join(REFERENCES_DIR, fname)
+            try:
+                with open(fpath) as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+            if isinstance(data, dict) and data.get("id") == arg:
+                return data, fpath, True
+
+    # 4. Not found
+    hint = ""
+    if os.path.isdir(REFERENCES_DIR):
+        hint = " Run with --list to see reference model IDs."
+    raise FileNotFoundError(f"Could not resolve '{arg}' as a file or reference model id.{hint}")
+
+
+def read_stdin_json():
+    if sys.stdin.isatty():
+        print("ERROR: No input. Pipe schema JSON on stdin, pass a file path, or pass a reference model id.", file=sys.stderr)
+        print_usage(sys.stderr)
+        sys.exit(1)
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Invalid JSON on stdin: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Output format converters
+# ---------------------------------------------------------------------------
+# arrows.app's default style block. We emit this on every export so that
+# pasting our JSON into https://arrows.app produces a sensible starting look,
+# and so that schemas exported from arrows.app and re-injected by us preserve
+# their look on a future export.
+ARROWS_DEFAULT_STYLE = {
+    "font-family": "sans-serif",
+    "background-color": "#ffffff",
+    "background-image": "",
+    "background-size": "100%",
+    "node-color": "#ffffff",
+    "border-width": 4,
+    "border-color": "#000000",
+    "radius": 50,
+    "node-padding": 5,
+    "node-margin": 2,
+    "outside-position": "auto",
+    "node-icon-image": "",
+    "node-background-image": "",
+    "icon-position": "inside",
+    "icon-size": 64,
+    "caption-position": "inside",
+    "caption-max-width": 200,
+    "caption-color": "#000000",
+    "caption-font-size": 50,
+    "caption-font-weight": "normal",
+    "label-position": "inside",
+    "label-display": "pill",
+    "label-color": "#000000",
+    "label-background-color": "#ffffff",
+    "label-border-color": "#000000",
+    "label-border-width": 4,
+    "label-font-size": 40,
+    "label-padding": 5,
+    "label-margin": 4,
+    "directionality": "directed",
+    "detail-position": "inline",
+    "detail-orientation": "parallel",
+    "arrow-width": 5,
+    "arrow-color": "#000000",
+    "margin-start": 5,
+    "margin-end": 5,
+    "margin-peer": 20,
+    "attachment-start": "normal",
+    "attachment-end": "normal",
+    "relationship-icon-image": "",
+    "type-color": "#000000",
+    "type-background-color": "#ffffff",
+    "type-border-color": "#000000",
+    "type-border-width": 0,
+    "type-font-size": 16,
+    "type-padding": 5,
+    "property-position": "outside",
+    "property-alignment": "colon",
+    "property-color": "#000000",
+    "property-font-size": 16,
+    "property-font-weight": "normal",
+}
+
+
+def to_arrows_app(ig):
+    """Produce arrows.app-compatible JSON from our normalised graph.
+
+    Conventions arrows.app uses (which differ from our internal shape):
+      - No top-level {graph: ...} wrapper. style/nodes/relationships sit at the root.
+      - caption is OPTIONAL and typically empty when it would equal labels[0];
+        the display text comes from labels[0]. We follow that rule here:
+        emit caption="" when caption == labels[0], otherwise pass the explicit
+        caption through. This keeps round-trips byte-stable and preserves any
+        unusual case where the user set a caption deliberately distinct from
+        the first label.
+      - Per-node style uses kebab-case (`node-color`, not `color`).
+    """
+    nodes_out = []
+    for n in ig["nodes"]:
+        labels = list(n["labels"])
+        primary = labels[0] if labels else ""
+        # Emit caption only when it diverges from the primary label
+        caption_out = "" if n["caption"] == primary else n["caption"]
+        nodes_out.append({
+            "id": n["id"],
+            "position": n["position"],
+            "caption": caption_out,
+            "style": {
+                "node-color": n["style"]["color"],
+                "radius": n["style"]["radius"],
+            },
+            "labels": labels,
+            "properties": dict(n["properties"]),
+        })
+    rels_out = [
+        {
+            "id": r["id"],
+            "type": r["type"],
+            "style": {},
+            "properties": dict(r["properties"]),
+            "fromId": r["fromId"],
+            "toId": r["toId"],
+        }
+        for r in ig["relationships"]
+    ]
+    return {
+        "style": dict(ARROWS_DEFAULT_STYLE),
+        "nodes": nodes_out,
+        "relationships": rels_out,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SVG renderer — a static rendering for environments where the .jsx can't run
+# ---------------------------------------------------------------------------
+def _xml_escape(s):
+    return (
+        str(s)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def render_svg(ig):
+    """Render the schema as an SVG that mirrors the editor's dark-theme canvas.
+
+    The point is to be useful in environments where the .jsx cannot render
+    (CLI tools, API users, README screenshots, slide decks). It mirrors the
+    editor's visual conventions closely — same dark background, label pills
+    below circles, fanned parallel relationships, monospace property text —
+    so a viewer can pattern-match between SVG and live editor.
+    """
+    nodes = ig["nodes"]
+    rels = ig["relationships"]
+    if not nodes:
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="120">'
+            '<rect width="320" height="120" fill="#0b1121"/>'
+            '<text x="160" y="60" text-anchor="middle" fill="#94a3b8" '
+            'font-family="sans-serif" font-size="14">Empty schema</text></svg>'
+        )
+
+    # Compute bounding box with padding for pills, properties, and rel labels
+    margin = 140
+    xs = [n["position"]["x"] for n in nodes]
+    ys = [n["position"]["y"] for n in nodes]
+    radii = [n["style"]["radius"] for n in nodes]
+    x_min = min(x - r for x, r in zip(xs, radii)) - margin
+    y_min = min(y - r for y, r in zip(ys, radii)) - margin
+    x_max = max(x + r for x, r in zip(xs, radii)) + margin
+    y_max = max(y + r for y, r in zip(ys, radii)) + margin
+    width = max(400, x_max - x_min)
+    height = max(300, y_max - y_min)
+
+    by_id = {n["id"]: n for n in nodes}
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="{x_min:.1f} {y_min:.1f} {width:.1f} {height:.1f}" '
+        f'width="{int(width)}" height="{int(height)}" '
+        f'font-family="-apple-system, BlinkMacSystemFont, sans-serif">',
+        f'<rect x="{x_min:.1f}" y="{y_min:.1f}" width="{width:.1f}" height="{height:.1f}" fill="#0b1121"/>',
+        '<defs><marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" '
+        'orient="auto" markerUnits="strokeWidth">'
+        '<polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/></marker></defs>',
+    ]
+
+    # Group rels by node-pair to fan parallel ones (matches the editor)
+    pair_groups = {}
+    for r in rels:
+        key = tuple(sorted([r["fromId"], r["toId"]]))
+        pair_groups.setdefault(key, []).append(r["id"])
+
+    # Relationships first (so nodes draw on top)
+    for r in rels:
+        f = by_id.get(r["fromId"])
+        t = by_id.get(r["toId"])
+        if not f or not t:
+            continue
+        type_str = _xml_escape(r["type"])
+        type_w = max(40, len(r["type"]) * 6.4 + 12)
+
+        if f["id"] == t["id"]:
+            # Self-loop: simple teardrop above the node
+            cx, cy = f["position"]["x"], f["position"]["y"]
+            rad = f["style"]["radius"]
+            parts.append(
+                f'<path d="M {cx - rad*0.4:.1f} {cy - rad*0.95:.1f} '
+                f'C {cx - rad*1.4:.1f} {cy - rad*2.4:.1f}, '
+                f'{cx + rad*1.4:.1f} {cy - rad*2.4:.1f}, '
+                f'{cx + rad*0.4:.1f} {cy - rad*0.95:.1f}" '
+                f'fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>'
+            )
+            label_x, label_y = cx, cy - rad * 1.9
+        else:
+            fx, fy = f["position"]["x"], f["position"]["y"]
+            tx, ty = t["position"]["x"], t["position"]["y"]
+            dx, dy = tx - fx, ty - fy
+            dist = (dx * dx + dy * dy) ** 0.5 or 1
+            ux, uy = dx / dist, dy / dist
+            # Trim line to node boundaries
+            x1 = fx + ux * f["style"]["radius"]
+            y1 = fy + uy * f["style"]["radius"]
+            x2 = tx - ux * t["style"]["radius"]
+            y2 = ty - uy * t["style"]["radius"]
+            siblings = pair_groups[tuple(sorted([f["id"], t["id"]]))]
+            idx = siblings.index(r["id"])
+            n_sib = len(siblings)
+            sign = 1 if r["fromId"] == sorted([f["id"], t["id"]])[0] else -1
+            lane = ((idx - (n_sib - 1) / 2) * 36 * sign) if n_sib > 1 else 0
+            nx_, ny_ = -uy, ux
+            ep_off = lane * 0.45
+            x1o, y1o = x1 + nx_ * ep_off, y1 + ny_ * ep_off
+            x2o, y2o = x2 + nx_ * ep_off, y2 + ny_ * ep_off
+            mx = (x1o + x2o) / 2 + nx_ * lane * 0.9
+            my = (y1o + y2o) / 2 + ny_ * lane * 0.9
+            if lane != 0:
+                parts.append(
+                    f'<path d="M {x1o:.1f} {y1o:.1f} Q {mx:.1f} {my:.1f} {x2o:.1f} {y2o:.1f}" '
+                    f'fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>'
+                )
+            else:
+                parts.append(
+                    f'<line x1="{x1o:.1f}" y1="{y1o:.1f}" x2="{x2o:.1f}" y2="{y2o:.1f}" '
+                    f'stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>'
+                )
+            label_x, label_y = mx, my
+
+        parts.append(
+            f'<rect x="{label_x - type_w/2:.1f}" y="{label_y - 16:.1f}" '
+            f'width="{type_w:.1f}" height="16" rx="4" fill="#0b1121" opacity="0.85"/>'
+        )
+        parts.append(
+            f'<text x="{label_x:.1f}" y="{label_y - 8:.1f}" text-anchor="middle" '
+            f'dominant-baseline="central" fill="#e2e8f0" font-size="10" '
+            f'font-family="monospace" font-weight="600">{type_str}</text>'
+        )
+
+    # Nodes
+    for n in nodes:
+        cx, cy = n["position"]["x"], n["position"]["y"]
+        rad = n["style"]["radius"]
+        color = n["style"]["color"]
+        caption = _xml_escape(n["caption"])
+        parts.append(
+            f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{rad}" '
+            f'fill="{color}26" stroke="{color}" stroke-width="2"/>'
+        )
+        font_size = 11 if len(n["caption"]) > 10 else 13
+        parts.append(
+            f'<text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" '
+            f'dominant-baseline="central" fill="#ffffff" font-size="{font_size}" '
+            f'font-weight="700" letter-spacing="0.5">{caption.upper()}</text>'
+        )
+        # Additional-label pills
+        extras = n["labels"][1:] if len(n["labels"]) > 1 else []
+        if extras:
+            char_w = 6
+            gap = 4
+            widths = [max(24, len(l) * char_w + 12) for l in extras]
+            total_w = sum(widths) + gap * (len(extras) - 1)
+            row_y = cy + rad + 8
+            cursor_x = cx - total_w / 2
+            for label, w in zip(extras, widths):
+                parts.append(
+                    f'<rect x="{cursor_x:.1f}" y="{row_y:.1f}" width="{w}" height="14" rx="7" '
+                    f'fill="{color}40" stroke="{color}" stroke-width="0.75"/>'
+                )
+                parts.append(
+                    f'<text x="{cursor_x + w/2:.1f}" y="{row_y + 7:.1f}" text-anchor="middle" '
+                    f'dominant-baseline="central" fill="#ffffff" font-size="9" '
+                    f'font-family="monospace" font-weight="600">:{_xml_escape(label)}</text>'
+                )
+                cursor_x += w + gap
+        # Properties
+        pill_row_h = 18 if extras else 0
+        for i, (k, v) in enumerate(n["properties"].items()):
+            text_y = cy + rad + 14 + pill_row_h + i * 14
+            parts.append(
+                f'<text x="{cx:.1f}" y="{text_y:.1f}" text-anchor="middle" '
+                f'fill="#cbd5e1" font-size="10" font-family="monospace">'
+                f'{_xml_escape(k)}: {_xml_escape(v)}</text>'
+            )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Main injection routine
+# ---------------------------------------------------------------------------
+def inject(raw_schema, output_path, source_label=None, is_reference_model=False):
+    ig = normalise_schema(raw_schema)
+
+    if not os.path.exists(TEMPLATE_PATH):
+        print(f"ERROR: Editor template not found at {TEMPLATE_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(TEMPLATE_PATH, "r") as f:
+        template = f.read()
+
+    new_initial = to_js_initial_graph(ig)
+    pattern = r"const initialGraph = \{[\s\S]*?\n\};"
+    if not re.search(pattern, template):
+        print("ERROR: Could not find 'const initialGraph = {...};' in template.", file=sys.stderr)
+        sys.exit(1)
+
+    output = re.sub(pattern, new_initial, template, count=1)
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w") as f:
+        f.write(output)
+
+    # Companion files share the .jsx basename. Three outputs from one schema:
+    #   .jsx  — the interactive editor (renders in claude.ai artifacts)
+    #   .json — arrows.app-compatible schema (paste into https://arrows.app)
+    #   .svg  — static rendering for environments without a JSX renderer
+    base = os.path.splitext(output_path)[0]
+    json_path = base + ".json"
+    svg_path = base + ".svg"
+
+    with open(json_path, "w") as f:
+        json.dump(to_arrows_app(ig), f, indent=2)
+
+    with open(svg_path, "w") as f:
+        f.write(render_svg(ig))
+
+    # Report
+    if is_reference_model and source_label:
+        meta = raw_schema if isinstance(raw_schema, dict) else {}
+        name = meta.get("name", os.path.basename(source_label))
+        desc = meta.get("description", "")
+        source = desc.split("Source: ")[-1] if "Source: " in desc else ""
+        print(f"Model:  {name}")
+        if source:
+            print(f"Source: {source}")
+    print(f"Nodes:  {len(ig['nodes'])}")
+    print(f"Rels:   {len(ig['relationships'])}")
+    print(f"Editor: {output_path}")
+    print(f"Schema: {json_path}")
+    print(f"Image:  {svg_path}")
+
+
+def print_usage(stream=sys.stdout):
+    print("Usage:", file=stream)
+    print("  python3 inject.py <reference-model-id>       [output.jsx]", file=stream)
+    print("  python3 inject.py <path/to/schema.json>      [output.jsx]", file=stream)
+    print("  cat schema.json | python3 inject.py          [output.jsx]", file=stream)
+    print("  python3 inject.py --list", file=stream)
+
+
+def main():
+    args = sys.argv[1:]
+
+    if args and args[0] in ("-h", "--help"):
+        print(__doc__)
+        print_usage()
+        return
+
+    if args and args[0] == "--list":
+        print_reference_list()
+        return
+
+    # Optional trailing .jsx output path
+    output_path = DEFAULT_OUTPUT
+    if args and args[-1].endswith(".jsx"):
+        output_path = args[-1]
+        args = args[:-1]
+
+    if len(args) > 1:
+        print("ERROR: Too many arguments.", file=sys.stderr)
+        print_usage(sys.stderr)
+        sys.exit(1)
+
+    source_label = None
+    is_reference_model = False
+
+    if len(args) == 1 and args[0] != "-":
+        try:
+            raw_schema, source_label, is_reference_model = resolve_input(args[0])
+        except FileNotFoundError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"ERROR: Invalid JSON in input file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        raw_schema = read_stdin_json()
+
+    try:
+        inject(raw_schema, output_path, source_label=source_label,
+               is_reference_model=is_reference_model)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Merge visual schema design capabilities from graph-schema-studio into neo4j-modeling-skill, combining theoretical modeling guidance with interactive artifact generation.

New capabilities:
- scripts/inject.py: unified injector producing .jsx, .json, and .svg
- assets/graph-editor-template.jsx: interactive React schema editor
- 32 pre-built reference models across 6 industries
- arrows.app JSON round-trip compatibility
- SVG static rendering for CLI/API environments
- Cypher export from the editor

SKILL.md restructuring:
- Added Visual Modeling section with injector workflow
- Added minimal schema shape and multi-label node guidance
- Added arrows.app round-trip and edit-save workflow
- Moved schema enforcement DDL to references/schema-enforcement.md
- Moved modeling patterns to references/modeling-patterns.md
- Added references/reference-models.md with full catalog
- Expanded description with visual modeling triggers
- Bumped version to 1.1.0

Why This Matters:
Before: the skill told agents how to model correctly but had no way to show schemas visually.
After: theoretical rigor + practical visual tooling in one skill — faster iteration, visual
validation, and shareable schemas.

All content stays under 500-line SKILL.md limit.
Linter passes. inject.py tested with reference models and custom domains.