### PR TITLE
docs: update Codex plugin installation

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "neo4j-skills-marketplace",
+  "interface": {
+    "displayName": "Neo4j Skills"
+  },
+  "plugins": [
+    {
+      "name": "neo4j-skills",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/neo4j-contrib/neo4j-skills.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Database"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -51,26 +51,21 @@ Use `/plugin list` to verify, or `/reload-plugins` after installation.
 ### Codex
 
 ```bash
-git clone https://github.com/neo4j-contrib/neo4j-skills.git
-mkdir -p ~/.codex/plugins
-cp -R neo4j-skills ~/.codex/plugins/neo4j-skills
+codex plugin marketplace add neo4j-contrib/neo4j-skills
+codex plugin add neo4j-skills@neo4j-skills-marketplace
 ```
 
-Add to `~/.agents/plugins/marketplace.json`:
+Verify marketplace and plugin availability:
 
-```json
-{
-  "name": "neo4j-marketplace",
-  "interface": { "displayName": "Neo4j Skills" },
-  "plugins": [
-    {
-      "name": "neo4j-skills",
-      "source": { "source": "local", "path": "./plugins/neo4j-skills" },
-      "policy": { "installation": "AVAILABLE" },
-      "category": "Database"
-    }
-  ]
-}
+```bash
+codex plugin marketplace list
+codex plugin list
+```
+
+Start a new Codex thread after installation so Codex loads the plugin. To refresh later:
+
+```bash
+codex plugin marketplace upgrade neo4j-skills-marketplace
 ```
 
 ## Available Skills


### PR DESCRIPTION
## Summary
- Replace the Codex installation section with the official codex plugin marketplace flow.
- Add Codex-native .agents/plugins/marketplace.json metadata so the marketplace exposes neo4j-skills correctly.
- Point the marketplace entry at the root Git-backed plugin source on main.

## Root Cause
The previous guide configured the marketplace source, but the repository did not expose a Codex-native marketplace entry.

## Validation
- git diff --cached --check
- python3 scripts/lint_skills.py
- Verified locally that codex plugin add neo4j-skills@neo4j-skills-marketplace --json installs version 1.0.1.

Running command locally
```
➜  neo4j-skills git:(codex-install-guide) pwd
/Users/jakub/workspaces/neo4j/neo4j-skills

➜  neo4j-skills git:(codex-install-guide) codex plugin marketplace add $PWD
Added marketplace `neo4j-skills-marketplace` from /Users/jakub/workspaces/neo4j/neo4j-skills.
Installed marketplace root: /Users/jakub/workspaces/neo4j/neo4j-skills

➜  neo4j-skills git:(codex-install-guide) codex plugin marketplace list
MARKETPLACE               ROOT
neo4j-skills-marketplace  /Users/jakub/workspaces/neo4j/neo4j-skills

➜  neo4j-skills git:(codex-install-guide) codex plugin list

Marketplace `neo4j-skills-marketplace`
/Users/jakub/workspaces/neo4j/neo4j-skills/.agents/plugins/marketplace.json

PLUGIN                                 STATUS         VERSION  PATH
neo4j-skills@neo4j-skills-marketplace  not installed           https://github.com/neo4j-contrib/neo4j-skills.git, ref `main`
```