### PR TITLE
Correct skills YAML

### DIFF
--- a/neo4j-cli-tools-skill/SKILL.md
+++ b/neo4j-cli-tools-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neo4j-cli-tools-skill
 description: Use when working with Neo4j command-line tools — neo4j-cli (modern unified
-  CLI: Cypher via Bolt, schema inspection, Aura management, Docker containers, credential
+  CLI — Cypher via Bolt, schema inspection, Aura management, Docker containers, credential
   management, agent skill catalog install; install with curl -sSfL https://neo4j.sh/install.sh | bash),
   neo4j-admin (backup, restore, import, memory sizing), cypher-shell (ad-hoc queries,
   scripting, CI/CD), or neo4j-mcp (quick MCP server install).

--- a/neo4j-driver-javascript-skill/SKILL.md
+++ b/neo4j-driver-javascript-skill/SKILL.md
@@ -4,7 +4,7 @@ description: Neo4j JavaScript/TypeScript Driver v6 — driver lifecycle, execute
   managed transactions (executeRead/executeWrite), session.run, Integer handling, JSON
   serialization, record access, async/await patterns, TypeScript types, error handling,
   and connection setup for Node.js and browser. Use when writing JS/TS code that connects
-  to Neo4j: neo4j.driver(), executeQuery, executeRead, executeWrite, session.run,
+  to Neo4j — neo4j.driver(), executeQuery, executeRead, executeWrite, session.run,
   neo4j.int, record.get, Integer, BookmarkManager, bolt://, neo4j+s://.
   Does NOT handle Cypher query authoring — use neo4j-cypher-skill.
   Does NOT cover driver version migration — use neo4j-migration-skill.

--- a/neo4j-mcp-skill/SKILL.md
+++ b/neo4j-mcp-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neo4j-mcp-skill
 description: Use when installing, configuring, or troubleshooting the official Neo4j MCP server
-  (neo4j/mcp): connecting Claude Code, Claude Desktop, Cursor, Windsurf, VS Code,
+  (neo4j/mcp) — connecting Claude Code, Claude Desktop, Cursor, Windsurf, VS Code,
   Kiro, or other MCP-compatible editors to a Neo4j database via stdio or HTTP
   transport. Covers the four MCP tools (get-schema, read-cypher, write-cypher,
   list-gds-procedures), read-only mode, and multi-database configuration.

--- a/neo4j-migration-skill/SKILL.md
+++ b/neo4j-migration-skill/SKILL.md
@@ -3,7 +3,7 @@ name: neo4j-migration-skill
 description: Migrates Neo4j driver code and Cypher queries from older versions (4.x, 5.x)
   to current (2025.x/2026.x, Cypher 25). Covers Python, JavaScript/Node.js, Java, .NET,
   and Go drivers — package renames, removed APIs, version requirements, diff-ready fixes.
-  Also handles Cypher syntax migration: QPE paths, CALL subqueries, id() → elementId(),
+  Also handles Cypher syntax migration — QPE paths, CALL subqueries, id() → elementId(),
   PERIODIC COMMIT → CALL IN TRANSACTIONS, and all Cypher 25 removals.
   Does NOT write new Cypher queries — use neo4j-cypher-skill.
   Does NOT cover DB administration or server ops — use neo4j-cli-tools-skill.

--- a/neo4j-spring-data-skill/SKILL.md
+++ b/neo4j-spring-data-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neo4j-spring-data-skill
-description: Use when building Spring Boot applications with Neo4j using Spring Data Neo4j (SDN 7.x/8.x):
+description: Use when building Spring Boot applications with Neo4j using Spring Data Neo4j (SDN 7.x/8.x) —
   @Node entity mapping, @Relationship, @RelationshipProperties, Neo4jRepository, ReactiveNeo4jRepository,
   @Query annotations, application.yml configuration, projections, Neo4jClient, Neo4jTemplate,
   transactions, auditing, or Spring AI Neo4jVectorStore vector search.

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -41,12 +41,24 @@ def parse_frontmatter(text: str) -> dict:
             m = re.match(r'^([\w-]+):\s*(.*)', line)
             if m:
                 current_key = m.group(1)
-                current_lines = [m.group(2)]
+                value = m.group(2)
+                stripped_value = value.strip()
+                quoted = (
+                    len(stripped_value) >= 2
+                    and stripped_value[0] in {'"', "'"}
+                    and stripped_value[-1] == stripped_value[0]
+                )
+                if not quoted and re.search(r':(?:[ \t]|$)', value):
+                    return None
+                current_lines = [value]
             else:
                 current_key = None
                 current_lines = []
         elif current_key is not None:
-            current_lines.append(line.strip())
+            value = line.strip()
+            if re.search(r':(?:[ \t]|$)', value):
+                return None
+            current_lines.append(value)
 
     if current_key is not None:
         result[current_key] = '\n'.join(current_lines).strip()


### PR DESCRIPTION
## Summary

Fix invalid skill frontmatter that caused skills@latest to omit five Neo4j skills from discovery.

  - Replace ambiguous :  separators in affected descriptions.
  - Extend the frontmatter parser to reject unquoted mapping-style colons.

## Verification

  - All 29 SKILL.md files pass linting.
  - skills@latest discovers all 29 skills.
  - Running lint script against main reveals the corrected frontmatter violations (`Found 5 frontmatter violation(s)`)